### PR TITLE
Add ALTER TABLE (ON DELETE CASCADE); run_mysql_script handle variable port numbers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,15 @@ After the `mysqlclient` package is installed manually run `pip install` using `r
 ## 2.0 Available scripts
 
 ### 2.1 run_mysql_script.py
-This python script is designed to process MySQL scripts.  The `run_mysql_script.py` script 
-requires a valid database connection provided via local *.yaml config file.  After opening a connection and creating a cursor, the script creates a list of SQL statements after splitting the SQL script on each semi-colon encountered (;).  The script then loops through the statements, attempting to execute each. If successful, the script commits the changes, closes the cursor and then closes the connection.  Otherwise, it rolls back the transaction and reports the error encountered.
+This python script is designed to process MySQL scripts.  The `run_mysql_script.py` script requires a valid database connection provided via local *.yaml config file.  After opening a connection and creating a cursor, the script creates a list of SQL statements after splitting the SQL script on each semi-colon encountered (;).  The script then loops through the statements, attempting to execute each. If successful, the script commits the changes, closes the cursor and then closes the connection.  Otherwise, it rolls back the transaction and reports the error encountered.
 
 #### 2.1.1 Create a .yaml configuration file
-Create a .yaml configuration file. The `run_mysql_script.py` script reads 
-this file in order to retrieve the database connection settings. Add the following database 
-connection settings to your .yaml file.  Make sure you set the `user` and `passwd` variables to the correct values. 
+Create a .yaml configuration file. The `run_mysql_script.py` script reads this file in order to retrieve the database connection settings. Add the following database connection settings to your .yaml file.  Make sure you set the `user` and `passwd` variables to the correct values. 
 
 ```yaml
 mysql:
   host: localhost
+  port: [yer port number, typically 3306]
   user: [yer MySQL user]
   passwd: [yer MySQL user password]
   db: unesco_heritage_sites

--- a/scripts/input/sql/unesco_heritage_sites.sql
+++ b/scripts/input/sql/unesco_heritage_sites.sql
@@ -375,6 +375,9 @@ SELECT ths.site_name,
 -- WARN: Django 2.x ORM does not recognize compound keys. Add otherwise superfluous primary key
 -- to accommodate a weak ORM.
 
+-- WARN: if a heritage_site record or country_area record is deleted the ON DELETE CASCADE
+-- will delete associated records in this junction/associative table.
+
 CREATE TABLE IF NOT EXISTS heritage_site_jurisdiction
   (
     heritage_site_jurisdiction_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
@@ -382,9 +385,9 @@ CREATE TABLE IF NOT EXISTS heritage_site_jurisdiction
     country_area_id INTEGER NOT NULL,
     PRIMARY KEY (heritage_site_jurisdiction_id),
     FOREIGN KEY (heritage_site_id) REFERENCES heritage_site(heritage_site_id)
-    ON DELETE RESTRICT ON UPDATE CASCADE,
+    ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (country_area_id) REFERENCES country_area(country_area_id)
-    ON DELETE RESTRICT ON UPDATE CASCADE
+    ON DELETE CASCADE ON UPDATE CASCADE
   )
 ENGINE=InnoDB
 CHARACTER SET utf8mb4

--- a/scripts/input/sql/unesco_heritage_sites_heritage_site_jurisdiction_cascade.sql
+++ b/scripts/input/sql/unesco_heritage_sites_heritage_site_jurisdiction_cascade.sql
@@ -1,0 +1,19 @@
+--
+-- WARNING: before running this script confirm that the foreign key names in the ALTER TABLE
+-- statement are correct before executing this script.
+--
+
+-- Drop heritage_site_jurisdiction foreign keys (and constraints)
+ALTER TABLE heritage_site_jurisdiction
+            DROP FOREIGN KEY heritage_site_jurisdiction_ibfk_1,
+            DROP FOREIGN KEY heritage_site_jurisdiction_ibfk_2;
+
+ALTER TABLE heritage_site_jurisdiction
+            ADD CONSTRAINT heritage_site_fk_heritage_site_id
+                           FOREIGN KEY (heritage_site_id)
+                           REFERENCES heritage_site(heritage_site_id)
+                           ON DELETE CASCADE ON UPDATE CASCADE,
+            ADD CONSTRAINT country_area_fk_country_area_id
+                           FOREIGN KEY (country_area_id)
+                           REFERENCES country_area(country_area_id)
+                           ON DELETE CASCADE ON UPDATE CASCADE;

--- a/scripts/run_mysql_script.py
+++ b/scripts/run_mysql_script.py
@@ -85,6 +85,7 @@ def connect_to_db(config):
 
 	return MySQLdb.connect(
 		host=config['host'],
+		port=config['port'],
 		user=config['user'],
 		passwd=config['passwd'],
 		db=config['db'],


### PR DESCRIPTION
This PR:
1. adds ALTER TABLE script to refresh heritage_site_jurisdiction FK constraints (ON DELETE CASCADE).
2. add port config entry to run_mysql_script.py.