### PR TITLE
Update Metropolitan Museum of Art data set scripts and csv files

### DIFF
--- a/scripts/input/sql/met_art.sql
+++ b/scripts/input/sql/met_art.sql
@@ -3,9 +3,7 @@
 --
 SET FOREIGN_KEY_CHECKS=0;
 DROP TABLE IF EXISTS artist, artwork, artwork_artist, artwork_attribution, artist_role,
-                     artwork_type, classification, city, country, department, region, repository,
-                     temp_artwork, temp_artwork_artist, temp_artwork_artist_attribution,
-                     temp_artwork_artist_role, temp_city, temp_classification, temp_region;
+                     artwork_type, classification, city, country, department, region, repository;
 SET FOREIGN_KEY_CHECKS=1;
 
 --
@@ -62,7 +60,7 @@ INTO TABLE country
 -- 2.3 temp city table
 -- Temp table includes lookup country_name.
 --
-CREATE TABLE IF NOT EXISTS temp_city (
+CREATE TEMPORARY TABLE temp_city (
   temp_city_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   city_name VARCHAR(255) NOT NULL UNIQUE,
   country_name VARCHAR(255) NULL,
@@ -109,11 +107,14 @@ SELECT tc.city_name, c.country_id
 WHERE TRIM(tc.city_name) IS NOT NULL AND TRIM(tc.city_name) != ''
 ORDER BY tc.city_name;
 
+-- Drop temp_city
+DROP TEMPORARY TABLE temp_city;
+
 --
 -- 2.5 temp region table
 -- Temp table includes lookup country_name.
 --
-CREATE TABLE IF NOT EXISTS temp_region (
+CREATE TEMPORARY TABLE temp_region (
   temp_region_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   region_name VARCHAR(255) NOT NULL UNIQUE,
   country_name VARCHAR(255) NULL,
@@ -160,11 +161,14 @@ SELECT tr.region_name, c.country_id
 WHERE TRIM(tr.region_name) IS NOT NULL AND TRIM(tr.region_name) != ''
 ORDER BY tr.region_name;
 
+-- Drop temp_region
+DROP TEMPORARY TABLE temp_region;
+
 --
 -- 2.6 temp classification table
 -- Temp table required because source data is messy.
 --
-CREATE TABLE IF NOT EXISTS temp_classification (
+CREATE TEMPORARY TABLE temp_classification (
   temp_classification_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   classification_name VARCHAR(255) NOT NULL UNIQUE,
   PRIMARY KEY (temp_classification_id)
@@ -206,6 +210,9 @@ SELECT classification_name
 FROM temp_classification tc
 WHERE TRIM(tc.classification_name) NOT like ',%'
 ORDER BY tc.temp_classification_id;
+
+-- Drop temp_classification
+DROP TEMPORARY TABLE temp_classification;
 
 --
 -- 2.8 department table
@@ -296,7 +303,7 @@ INTO TABLE repository
 -- Link Resource
 -- Repository
 
-CREATE TABLE IF NOT EXISTS temp_artwork (
+CREATE TEMPORARY TABLE temp_artwork (
   temp_artwork_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   accession_number VARCHAR(50) NULL,
   is_public_domain CHAR(5) NULL,
@@ -479,6 +486,9 @@ SELECT ta.accession_number,
               ON TRIM(ta.repository_name) = TRIM(repo.repository_name)
  ORDER BY ta.temp_artwork_id;
 
+-- Drop temp_artwork
+DROP TEMPORARY TABLE temp_artwork;
+
 --
 -- 3.3 Artist table
 --
@@ -503,7 +513,7 @@ INTO TABLE artist
   (artist_display_name);
 
 --
--- 3.4 Temp artist role table
+-- 3.4 artist role table
 -- WARN: 2nd row empty value (IGNORE 2 LINES)
 --
 CREATE TABLE IF NOT EXISTS artist_role (
@@ -530,7 +540,7 @@ INTO TABLE artist_role
 -- 3.5 Temp artwork_artist M2M junction table
 --
 --
-CREATE TABLE IF NOT EXISTS temp_artwork_artist_role (
+CREATE TEMPORARY TABLE temp_artwork_artist_role (
   temp_artwork_artist_role_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   accession_number VARCHAR(50) NOT NULL,
   artwork_artist_index INTEGER NOT NULL,
@@ -579,7 +589,7 @@ INTO TABLE artwork_attribution
 -- 3.7 Temp artwork_artist_attribution M2M junction table
 --
 --
-CREATE TABLE IF NOT EXISTS temp_artwork_artist_attribution (
+CREATE TEMPORARY TABLE temp_artwork_artist_attribution (
   temp_artwork_artist_attribution_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   accession_number VARCHAR(50) NOT NULL,
   artwork_artist_index INTEGER NOT NULL,
@@ -604,7 +614,7 @@ INTO TABLE temp_artwork_artist_attribution
 --
 -- 3.8 Temp artwork_artist M2M junction table
 --
-CREATE TABLE IF NOT EXISTS temp_artwork_artist (
+CREATE TEMPORARY TABLE temp_artwork_artist (
   temp_artwork_artist_id INTEGER NOT NULL AUTO_INCREMENT UNIQUE,
   accession_number VARCHAR(50) NOT NULL,
   artwork_artist_index INTEGER NOT NULL,
@@ -679,3 +689,8 @@ SELECT art.artwork_id, aa.artwork_attribution_id, taa.artwork_artist_index,
        LEFT JOIN artwork_attribution aa
               ON TRIM(taaa.artwork_attribution) = TRIM(aa.artwork_attribution)
  ORDER BY artwork_id, artwork_artist_index;
+
+ -- Drop remaining temp tables
+DROP TEMPORARY TABLE temp_artwork_artist_role;
+DROP TEMPORARY TABLE temp_artwork_artist_attribution;
+DROP TEMPORARY TABLE temp_artwork_artist;

--- a/scripts/output/met_artwork/met_artists_unique.csv
+++ b/scripts/output/met_artwork/met_artists_unique.csv
@@ -1,0 +1,1162 @@
+artist
+'Abd al-Qadir Hisari
+'Abdullah ibn al-Fadl
+"Abbott, Berenice"
+"Abels, Ludwig"
+Abu'l Qasim Firdausi
+Achilles Painter
+"Adam, Robert"
+"Adamson, Robert"
+"Adhikari, Murari"
+"Adrian, Gilbert"
+Adrover Miguel
+"Aetna Silkscreen Products, Inc."
+"Aguado de las Marismas, Onésipe"
+Al-Sufi `Abd al-Rahman
+"Albers, Josef"
+"Alembert, Jean Le Rond d'"
+Alexander McQueen
+"Alexandre, Arsène"
+"Alken, Sefferin"
+"Alpert, Richard"
+"Altdorfer, Albrecht"
+Amasis Painter
+Amati Andrea
+"Amelung, John Frederick"
+American Flint Glass Manufactory 
+American Pottery Manufacturing Company
+American Tobacco Company
+American Union of Decorative Artists and Craftsmen
+Amir Khusrau Dihlavi
+"Amman, Jost"
+"Anatsui, El"
+Andokides
+Andokides Painter
+"Andreoli, Giorgio Maestro"
+"Andrews, Benny"
+"Andrews, William Loring"
+Angas George French
+Anonymous
+Anonymous Flemish weavers
+"Anshutz, Thomas"
+"Antico (Alari Bonacolsi, Pier Jacopo)"
+"Apianus, Georg and Petrus"
+"Apianus, Petrus"
+Appleton & Co.
+"Appleton, Thomas"
+"Apvd Gvlielmvm, svb scvto veneto"
+"Arbus, Diane"
+"Argens, Jean-Baptiste de Boyer, marquis d'"
+"Ariosto, Ludovico"
+Armani Giorgio
+"Armitt, Joseph"
+Arndts Johan
+Arnold Seneuse
+"Atget, Eugène"
+Athabascan Family
+"Audran, Girard"
+"Auguste, Charles, marquis de La Fare"
+"Avery, Milton"
+"Avery, Samuel Putnam, Sr."
+"Avril, Paul"
+"Bacon, Francis H."
+"Bacot, Edmond"
+Badi' al-Zaman ibn al-Razzaz al-Jazari
+"Bakewell, Page & Bakewell"
+"Bakst, Léon"
+"Baldung, Hans (called Hans Baldung Grien)"
+"Baldus, Édouard"
+Balenciaga House of
+"Balenciaga, Cristobal"
+Balthus (Balthasar Klossowski)
+Bamen Tomotsugu
+"Baranik, Rudolf"
+Barbou
+"Baronzio, Giovanni"
+Barrie
+"Barry, and Son Joseph B."
+Bartolo di Fredi
+"Bartolomeo, Fra (Bartolomeo di Paolo del Fattorino)"
+Basawan
+"Bassano, Jacopo (Jacopo da Ponte)"
+"Bastien-Lepage, Jules"
+Bastis Master
+Baudoin Joseph-François-Xavier
+Baudouin
+"Bauer, Johann Michael"
+"Baur, Daniel"
+"Baziotes, William"
+"Bearden, Romare"
+"Beardsley, Aubrey Vincent"
+"Beaux, Cecilia"
+"Beckmann, Max"
+Beissbarth & Hoffmann
+"Belleau, Remy"
+"Bellini, Giovanni"
+"Bellows, George"
+"Belter, J. H."
+"Belzoni, Giovanni Battista"
+"Benbridge, Henry"
+Benedetto da Maiano
+"Bening, Simon"
+"Bennett, John"
+"Bensley, Thomas"
+"Benton, Thomas Hart"
+Benvenuto di Giovanni
+"Berain, Jean"
+Berlin Painter
+Bernard Quaritch Ltd.
+"Bernard, Léopold"
+Berners Juliana
+"Bernieres, de"
+"Bernini, Gian Lorenzo"
+"Bernini, Pietro"
+Bhawani Das
+Biblioteca Nazionale Marciana
+"Bidermann, Samuel"
+"Biennais, Martin-Guillaume"
+"Bierstadt, Albert"
+Bihzad
+"Bingham, George Caleb"
+"Bishop, Heber R."
+Black Emergency Cultural Coalition and Artists and Writers Protest Against the War in Vietnam
+Black Stone Press
+"Blackburn, Joseph"
+"Blaeu, Johannes"
+"Blake, George Henry"
+"Blanc, Charles"
+"Blass, Bill"
+Blemly William Ignatius
+Blockley Thomas
+"Blume, Peter"
+"Boccaccio, Giovanni"
+"Boccalini, Traiano"
+"Boccioni, Umberto"
+Boch Jean
+"Boekhout, Thomas Coenraet"
+"Boileau Despréaux, Nicolas"
+"Boito, Camillo"
+"Bonheur, Rosa"
+"Bonnard, Pierre"
+"Bononome, Giuseppe"
+Bonwit Teller & Co.
+"Borch, Gerard ter, the Younger"
+"Borchardt, Ludwig"
+"Borcht, Peeter van der"
+Boslwert A.
+Boston and Sandwich Glass Company
+"Botero, Fernando"
+Botticelli (Alessandro di Mariano Filipepi)
+"Bouchard, Giovanni"
+"Boucher, François"
+"Bouillat père, Edme François"
+"Boulle, André Charles"
+"Bourgeois, Louise"
+Bousch Valentin
+"Boutet, Nicholas-Noël"
+"Bozerian, Jean Claude"
+"Brady, Mathew B."
+Brainerd Ira Hutchinson
+"Brancusi, Constantin"
+Brandely Jean
+"Brandt, Bill"
+"Brandt, Marianne"
+"Braque, Georges"
+Brassaï
+"Braun, Adolphe"
+"Bret, M. (Antoine)"
+"Briani, Girolamo"
+Briasson
+"Briosco, Andrea, called Riccio"
+Bronzino (Agnolo di Cosimo di Mariano)
+"Broodthaers, Marcel"
+"Brotto, Carlo Bertoncello"
+"Brown, W. and O'Neil A."
+"Bruegel, Pieter, the Elder"
+"Brueghel, Jan, the Elder"
+"Brugghen, Hendrick ter"
+"Brun, J. C. A."
+Buli Master
+Bunsen Franz Peter
+"Buonanni, Filippo"
+"Burne-Jones, Edward, Sir"
+"Bush, Andrew"
+Bushell Stephen Wootton Dr.
+"Bustamante, Jean-Marc"
+"Bustelli, Franz Anton"
+Byrdcliffe Arts and Crafts Colony
+"Böckler, Georg Andreas"
+"Böcklin, Arnold"
+"Calder, Alexander"
+"Callahan, Harry"
+Callot Soeurs
+Cambridge University Press
+"Cameron, Julia Margaret"
+"Camilli, Camillo"
+"Campin, Robert"
+Canaletto (Giovanni Antonio Canal)
+"Canova, Antonio"
+Caravaggio (Michelangelo Merisi)
+"Carducho, Vincente"
+"Carlin, Martin"
+"Caro, Anthony"
+"Carpaccio, Vittore"
+"Carpeaux, Jean-Baptiste"
+"Carpi, Ugo da"
+"Carracci, Annibale"
+"Carradori, Francesco"
+"Carrington, Leonora"
+"Cassatt, Mary"
+"Castiglione, Giovanni Benedetto (Il Grechetto)"
+Catholic Church
+"Cesnola, Luigi Palma di"
+Chaignieau
+Chakalte'
+"Champigneulle, Jacques-Charles"
+"Chanel, Gabrielle ""Coco"""
+"Chanel, House of"
+"Chardin, Jean Siméon"
+"Chase, William Merritt"
+"Chauvassaignes, Franck-François-Genès"
+"Chauvet, Jules Adolphe"
+"Chevreul, Michel Eugène"
+Chez Desnos
+Chez Jubert
+"Chippendale, Thomas"
+"Chirico, Giorgio de"
+Chitarman
+"Chizzola, Luigi"
+"Choiselat, Marie-Charles-Isidore & Stanislas Ratel"
+"Christus, Petrus"
+"Church, Frederic Edwin"
+Clark John
+Claude Laurent
+Claude Lorrain (Claude Gellée)
+Clodion (Claude Michel)
+"Close, Chuck"
+Clousier
+Cobb John
+"Coburn, Alvin Langdon"
+"Cochin, Charles Nicolas, I"
+"Cochin, Charles Nicolas, II"
+"Coggeshall, Patty"
+"Cohen, Claudia"
+"Cole, Thomas"
+"Coleman, Charles Caryl"
+"Colin et Cie., Éditeurs"
+"Collombat, Jacques"
+"Colt, Samuel"
+Comme des Garçons
+Compagnie des libraires associés
+"Condivi, Ascanio"
+"Constable, John"
+"Conti, Giovan Stefano"
+"Convent of Saint Joseph-de-la-Providence, Paris"
+"Copley, John Singleton"
+"Corot, Camille"
+"Cour, Jean"
+"Courbet, Gustave"
+"Courrèges, André"
+Courtois frères
+"Cousin, Jean, the Elder"
+"Cranach, Lucas, the Elder"
+"Crawford, Thomas"
+Cristofori Bartolomeo
+Croly George Rev.
+"Cropsey, Jasper Francis"
+"Cross, Henri-Edmond"
+"Cuntz, Steffan"
+"Curran, John T."
+"Curry, John Steuart"
+Curtius Ernst
+"Custos, Dominicus"
+"Cuvelier, Eugène"
+"Cézanne, Paul"
+"Daddi, Bernardo"
+"Dalí, Salvador"
+"Dapper, Olfert"
+"Daumier, Honoré"
+"Davenport, A. H."
+"David, Gerard"
+"David, Jacques Louis"
+"Davis, Joseph H."
+"Davis, Stuart"
+"De Kooning, Willem"
+De Vinne Press
+"Deburau, Jean-Charles"
+"Degas, Edgar"
+"Delacroix, Eugène"
+"Delaune, Étienne"
+"Demuth, Charles"
+Denis de Sainte-Marthe
+"Dennis, Thomas"
+"Denon, Dominique Vivant Baron"
+"Derain, André"
+"Desplaces, Louis"
+"Deutschmann, Joseph"
+"Dewing, Thomas Wilmer"
+"Diderot, Denis"
+"Didot, François Ambroise"
+"Didot, Pierre l'ainé"
+Diehl Charles-Guillaume
+"Dijon, V."
+"Diodati, Ottaviano"
+"Dior, Christian"
+"Dior, House of"
+"Dittrich, Edith"
+"Dix, Otto"
+"Dodin, Charles Nicolas"
+Donatello
+"Doucet, Jacques"
+"Douglas, Aaron"
+Drecoll
+"Dresser, Christopher"
+"Drouart, Jean"
+Du-Art Displays
+"Dubuffet, Jean"
+Duccio di Buoninsegna
+"Duchamp, Marcel"
+"Duflos, Claude"
+"Dugourc, Jean Démosthène"
+"Dunand, Jean"
+"Dunn, Henry Treffry"
+"Dupas, Jean"
+"Duplessis, Jean-Claude"
+Durand
+"Durand, Asher Brown"
+"Dwiggins, William Addison"
+"Dyck, Anthony van"
+"Dézallier d'Argenville, Antoine Joseph"
+"Dürer, Albrecht"
+"Eakins, Thomas"
+"Earl, Ralph"
+"Edmonds, Francis William"
+"Edouart, Auguste"
+"Eisen, Charles Dominique Joseph"
+Elevated Tone Workshop
+Elseviers
+"Emmoser, Gerhard"
+"Enríquez, Nicolás"
+Epimenes
+Eretria Painter
+"Ernst, Max"
+"Ertel, Giacomo (Jacob)"
+"Esherick, Wharton"
+Esposito Giosue
+"Estienne, Robert"
+"Eugenico, Niccolò"
+Euphiletos Painter
+"Evans, Walker"
+Exekias
+"Eyck, Jan van"
+Ezra
+Factory Additions
+"Faigenbaum, Patrick"
+"Falls, Charles B."
+"Fannière, François-Auguste"
+"Fannière, François-Joseph-Louis"
+Farid al-Din `Attar
+"Farrer, Henry"
+Farrukh ibn `Abd al-Latif
+Fath House of Jacques
+Fath Jacques
+"Feininger, T. Lux"
+"Fenton, Roger"
+"Fernández, Francisco"
+Ferragamo Salvatore
+"Ferriss, Hugh"
+"Fielding, Theodore Henry Adolphus"
+"Finlay, Hugh"
+"Finlay, John"
+"Fisher, Robert"
+"Fitch, Julia Ann"
+"Fletcher, Thomas"
+"Foggini, Giovanni Battista"
+"Folengo, Theophilo"
+"Fontana, Giovanni Battista"
+Ford Tom
+"Fort, Louis"
+Fortuny
+"Fortuny, Mariano"
+"Fouquet, Georges"
+"Fouquet, Jean"
+Fourteen identified German (Augsburg) goldsmiths and other Germa
+"Fragonard, Jean Honoré"
+Franceschi Francesco de'
+Francesco di Giorgio Martini
+"Frankl, Paul T."
+French
+"French, Daniel Chester"
+"Freud, Lucian"
+"Friedrich, Caspar David"
+"Froehner, Wilhelm"
+Frémiet Emmanuel
+Fulper Pottery Company
+"Furman, Warner Williams Sarah"
+"Fuss, Adam"
+"Fénelon, François de Salignac de La Mothe-"
+GONG XIAN
+"Gahn, Johann Benedikt"
+"Gainsborough, Thomas"
+Galeria Arte Global
+"Gallet, George"
+Galliano John
+Ganda
+"Gardiner, Sidney"
+"Gardner, Alexander"
+"Gardner, Caleb"
+Garion
+"Garnier, Jules"
+"Garofolo, Girolamo"
+"Garthwaite, Anna Maria"
+"Gaucherel, Léon"
+"Gaudissard, Emile"
+"Gauguin, Paul"
+Gaultier Jean Paul
+"Gemlich, Ambrosius"
+"Gerhaert von Leyden, Niclaus"
+"Gericault, Théodore"
+"Germain, François Thomas"
+"Gernreich, Rudi"
+Gervais Elie
+"Giacometti, Alberto"
+Giambologna
+Gianni Versace
+"Gibbs, Josiah W. (Josiah Willard)"
+"Gifford, Sanford Robinson"
+Gilbert John
+"Gilbert, S. & T."
+"Gilles, Pierre"
+Giotto di Bondone
+Giovanni di Paolo (Giovanni di Paolo di Grazia)
+"Giuntini, Vincenzo"
+Givenchy House of
+"Givenchy, Hubert de"
+"Glackens, William James"
+Glassgold A. C.
+"Gogh, Vincent van"
+Gorham Manufacturing Company
+"Gorky, Arshile"
+Gotō Yūjō
+"Goullons, Jacques"
+Govardhan
+Goya (Francisco de Goya y Lucientes)
+"Graf, Urs"
+"Graham, John"
+Grancino Giovanni
+"Grand-Carteret, John"
+Grecke Johan Adolph
+"Greco, El (Domenikos Theotokopoulos)"
+"Greene, John Beasley"
+"Gregori, Carlo"
+Grenser H.
+"Greuze, Jean-Baptiste"
+Grittel Èmile
+"Grooms, Red"
+"Gros, Jean-Baptiste-Louis"
+"Groto, Luigi"
+Group of Boston 00.348
+Grouwels Lodewijck
+"Grès, Madame"
+"Guardi, Francesco"
+Gucci
+Guercino (Giovanni Francesco Barbieri)
+Gufram
+Guo Xi
+"Gursky, Andreas"
+"Guston, Philip"
+"Guy, Seymour Joseph"
+"Guélard, J. B."
+"Gérôme, Jean-Léon"
+HAN GAN
+HUANG TINGJIAN
+Haas Johann Wilhelm
+Habiballah
+Hafiz
+"Haghe, Louis"
+"Halder, Jacob"
+Hallé
+"Hals, Frans"
+Halston
+"Hamilton, Anthony, Count"
+"Hammons, David"
+"Hannock, Stephen"
+Hans of Landshut
+Hardy-Mennil
+Harper & Brothers
+Harris H.
+"Hartley, Marsden"
+"Hassam, Childe"
+"Hathaway, Rufus"
+Hatifi
+"Hauser, Hermann"
+"Hauslaib, Lorenz"
+"Hawes, Josiah Johnson"
+Hayashi Kodenji
+"Hayashi, Tadamasa"
+"Heade, Martin Johnson"
+"Healy, George P. A."
+Heavenly Monkey
+"Heiglen, Johann Erhard"
+Heinrich of Constance Master
+"Helmschmid, Kolman"
+"Henle, Jan"
+"Hepplewhite, A. & Co."
+"Hepworth, Barbara"
+Herter Brothers
+"Hey, Jean (called Master of Moulins)"
+"Hicks, Edward"
+Hill and Adamson
+"Hill, David Octavius"
+"Hine, Lewis"
+Hirschfeld Workshop
+"Hobcraft, John"
+"Hodgson, Barbara"
+"Hoentschel, Georges"
+"Hoffmann, Josef"
+Hofmann Ferdinand
+"Holbein, Hans, the Younger"
+"Holden, Richard"
+"Homer, Winslow"
+"Hooch, Pieter de"
+"Hooghe, Romeyn de"
+"Hopper, Edward"
+"Houdon, Jean Antoine"
+Houghton Mifflin Company
+"Houry, Laurent Charles d'"
+Hugo Boss
+Huizong Emperor
+Hukin & Heath
+"Humbert, de Superville David-Pierre Giottino"
+"Humblot, Antoine"
+"Hunter, Dard"
+"Hunzinger, George Jakob"
+HÉBRARD A. A.
+"Hérissant, La Veuve"
+"Ibn al-Suhrawardi al-Bakri, Ahmad"
+Imperial Armory
+"Imperial Porcelain Manufactory, St. Petersburg"
+Imprimerie de Testu
+Ince William
+Ince and Mayhew
+"Ingham, Charles Cromwell"
+"Ingres, Jean Auguste Dominique"
+"Inness, George"
+Ishiguro Masayoshi
+Italian
+"Italian, Siena"
+Itoh Takuo
+Iwamoto Konkan
+"Iyetada, Saotome"
+Ja'far ibn Muhammad ibn `Ali
+"Jackson, Samuel"
+"Jacob, Georges"
+Jacob-Desmalter François-Honoré-Georges
+"Jacobs, Marc"
+Jacometto (Jacometto Veneziano)
+"Jacques, Maurice"
+James Charles
+Jeffrey & Co.
+John Devall & Co.
+"Johns, Jasper"
+"Johnson, David"
+"Johnson, Eastman"
+"Johnson, James Weldon"
+"Joly, Robert "
+"Jombert, Charles Antoine"
+"Jones, Owen"
+Joubert Gilles
+"Juvenal, Decimus Junius"
+Kamal Muhammad
+Kamali Norma
+"Kandinsky, Vasily"
+Kang Ji
+Kano Sansetsu
+"Kapoor, Anish"
+"Kaunitz-Rietberg, Prince Wenzel von"
+"Kelly, Ellsworth"
+"Kensett, John Frederick"
+Kephisodotos
+"Kertész, André"
+"Kiefer, Anselm"
+"Kierstede, Cornelius"
+"Kilburn, (or Kilbrunn) Lawrence"
+"Kim, Kwang Ju"
+Kintzing Christian
+Kirchner Athanasius
+Kirchner Johann Gottlieb
+"Klee, Paul"
+Kleihnans
+"Klein, William"
+"Klimt, Gustav"
+"Knoedler, M., & Co."
+Koyate Mamadou
+"Krasner, Lee"
+Kunitoshi Rai
+"Kuntz, Jacob"
+Kunz George Frederick
+"Käsebier, Gertrude"
+Kōrin
+L'Imprimerie Royale
+LEINBERGER HANS
+LIMOSIN LÉONARD
+LIONARDO
+"La Farge, John"
+"La Fontaine, Jean de"
+"La Porte du Theil, François Jean Gabriel de"
+"La Tour, Georges de"
+La Veuve Besongne & Fils
+"Lachaise, Gaston"
+Lacroix Christian
+"Lalique, René-Jules"
+"Lambert, Michel"
+"Lamire, Leon"
+"Landon, Charles-Paul"
+"Lane, Fitz Henry"
+"Lange, Dorothea"
+Langenbucher Veit
+Langlois
+Langlois Peter
+"Lannuier, Charles-Honoré"
+"Lanvin, House of"
+"Lanvin, Jeanne"
+"Latapie, François de Paule"
+"Lavaur, M. (Guillaume de)"
+"Lavezzola, Alberto"
+"Lawrence, Jacob"
+"Lawrence, Thomas, Sir"
+"Le Bourgeois, Marin"
+"Le Bourgeois, Pierre"
+"Le Brun, Charles"
+"Le Gray, Gustave"
+"Le Moine, L. H."
+Le Roux Hugues
+"Le Secq, Henri-Jean-Louis"
+"Leary, Timothy"
+Lekeux Peter
+Lemoyen le Lorrain Jean
+Lemoyne Jean-Louis
+"Leonard, Robert"
+Leonardo da Vinci
+"Lepsius, Richard"
+"Leutze, Emanuel"
+"Leyden, Lucas van"
+"Lichtenstein, Roy"
+"Liger, C."
+"Lilley, Robert"
+"Lippi, Filippino"
+"Lippi, Fra Filippo"
+"Lissitzky, El"
+"Lochner, Kunz"
+"Lodigiani, Luigi"
+"Lomazzo, Giovanni Paolo"
+"Lonberg-Holm, Knud"
+London Society of Cabinet Makers
+"Longfellow, Henry Wadsworth"
+"Lorenzetti, Pietro"
+Lorenzo Monaco (Piero di Giovanni)
+"Lotto, Lorenzo"
+"Louis, Morris"
+Louiseboulanger
+"Lucas, David"
+Lycurgus Painter
+Lydos
+Lysippides Painter
+"Léger, Fernand"
+"Lévy-Dhurmer, Lucien"
+"López, Francisco"
+MEMPHIS MILANO
+"MacMonnies, Frederick William"
+"MacNeil, Hermon Atkins"
+"Mackintosh, Charles Rennie"
+Maestro delle Storie del Pane
+Mahmud Muzahib
+"Maiano, Giuliano da"
+Mainbocher
+Maison Léoty
+"Malato, Enrico"
+Malory Thomas Sir
+Malthus Francis
+Man Ray
+"Manet, Édouard"
+Mannello Angelo
+Manohar
+"Mantegna, Andrea"
+Manufacture Nationale des Gobelins
+Marcilly
+"Marin, John"
+Marius Michel et fils
+"Marmitta, Francesco"
+"Marquet, Albert"
+"Martel, Charles"
+Martin Christian Frederick
+"Martin, Docteur (Louis)"
+Martinellie Domenico
+"Martinez, Juan"
+"Martini, Simone"
+"Martínez, Francisco"
+Martínez Montañés Juan
+Master IC
+Master Potter A
+Master of Saint Francis
+Master of the Codex of Saint George
+Master of the Martyrdom of St. Sebastian
+"Matisse, Henri"
+"Matta, Roberto"
+"Matta-Clark, Gordon"
+Maulana Azhar
+Mayhew John
+"Mazzinelli, Alessandro"
+McCardell Claire
+"McIntire, Samuel"
+McQueen Alexander
+"Mead, Larkin Goldsmith"
+"Meares, Richard"
+Medici Porcelain Factory
+Meissen Manufactory
+Mekeren Jan van
+"Memling, Hans"
+"Merwede, Matthuys van de, Lord of Clootwyck"
+"Messerschmidt, Franz Xaver"
+Metropolitan Museum of Art
+"Metzker, Ray K."
+"Metzner, Ralph"
+"Michaux, Henri"
+Michelangelo Buonarroti
+"Mies van der Rohe, Ludwig"
+"Mignard, Pierre"
+"Miller, Herman Inc."
+"Miller, Sally"
+"Milton, John"
+Min Qiji
+Ministère de l'intérieur
+Mir 'Ali Haravi
+"Miró, Joan"
+Miskin
+"Model, Lisette"
+"Modigliani, Amedeo"
+"Molière, Jean-Baptiste Poquelin"
+"Molyneux, Edward"
+"Monet, Claude"
+"Monnet, Jean"
+"Montecuccoli, Raimondo, Prince"
+Montespan Marquise de
+"Moreau, Jean Michel, the Younger"
+"Morgan, J. Pierpont"
+"Morice, Charles"
+Morisset James
+Morris & Company
+"Morris, Marshall, Faulkner & Co."
+"Morris, William"
+"Morse, Samuel F. B."
+Mosca Simone
+"Motherwell, Robert"
+"Mouchon, Pierre"
+"Moulin, Félix-Jacques-Antoine"
+"Mount, William Sidney"
+"Moura Portugal, Bento de"
+"Moynet, Simon"
+"Mozart, Anton"
+Muhammad Chand
+Muhammad Husain Kashmiri
+Muhammad ibn Aibak ibn 'Abdallah
+Muhammad ibn Badr al-Din Jajarmi
+"Muneakira, Myōchin"
+"Munesuke, Myōchin"
+"Muniz, Vik"
+"Munro, Rebekah S."
+"Murer, Christoph"
+"Murillo, Bartolomé Estebán"
+"Murray, Elizabeth"
+Museu de Arte Moderna
+Muslim Ibn al-Dahhan
+Mustafa b. Yusuf al-Darir al-Erzerumi
+"Myers, Myer"
+Mynardo Giovanni
+"Müller, Karl L. H."
+Nadar
+"Naeplaesnigg, Andreas"
+"Nannini, Remigio"
+"Naville, Édouard F."
+Nearchos
+"Negroli, Filippo"
+"Neilson, Jacques"
+New Bremen Glass Manufactory 
+Niccolò di Buonaccorso
+Nicola da Urbino
+"Nie, Chongyi"
+"Nimmo, J. C. and Bain"
+Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
+"Noguchi, Isamu"
+Norman Barak
+"Noyse von Campenhouten, Johann Engelbert"
+Nunns Robert
+Nymphenburg Porcelain Manufactory
+"Nègre, Charles"
+"O'Keeffe, Georgia"
+"O'Sullivan, Timothy H."
+"Oberlender, Johann Wilhelm"
+"Oeben, Jean-François"
+"Ohr, George E."
+"Oiticica, Hélio"
+"Oldenburg, Claes"
+Olowe of Ise
+"Ongania, Ferdinando"
+"Onofri, Basilio"
+Oppenordt Alexandre-Jean
+"Orley, Bernard van"
+Osservanza Master
+"Ostade, Adriaen van"
+"Ostendorfer, Michael"
+Ovid
+PBM
+PUCELLE JEAN
+"Pabst, Daniel"
+"Pacetti, Giovanni Battista"
+"Pacetti, Vincenzo"
+Padeloup
+Painter of the Woolly Satyrs
+"Pajou, Augustin"
+"Palissy, Bernard"
+"Palladio, Andrea"
+"Palmer, Erastus Dow"
+"Panini, Giovanni Paolo"
+"Pannemaker, Pieter de"
+Pantin Simon I
+"Pape, Lygia"
+Paquin House of
+Paquin Jeanne
+"Passeri, Giuseppe"
+"Patinir, Joachim"
+"Patisson, Mamert"
+"Patou, House of"
+"Peale, Charles Willson"
+"Peale, James"
+"Peale, Raphaelle"
+"Peale, Rembrandt"
+"Peck, Peter"
+"Pellerin, Baptiste"
+"Penn, Irving"
+Penthesilea Painter
+"Percier, Charles"
+Pere Alexandre & Fils
+Perino del Vaga (Pietro Buonaccorsi)
+Permoser Balthasar
+"Pernon, Camille"
+Persephone Painter
+Persius
+"Peruzzi, Baldassare Tommaso"
+Pesquera Diego de
+Petronius Arbiter
+Pfau David II
+Pfau Hans Heinrich III
+"Phyfe, Duncan"
+"Picasso, Pablo"
+Piero di Cosimo (Piero di Lorenzo di Piero d'Antonio)
+Pierre Paupie
+Pierre de Goesin
+"Pigna, Giovanni Battista"
+"Pippin, Horace"
+"Piranesi, Giovanni Battista"
+"Pisano, Giovanni"
+"Pithou, Pierre"
+"Plandome Press, Inc."
+"Plon E., Nourrit et Cie."
+Plutarch
+"Poiret, Paul"
+"Polke, Sigmar"
+"Pollaiuolo, Antonio"
+"Pollock, Jackson"
+Polykleitos
+Polyteleia Painter
+"Pons, Joseph"
+"Porro, Girolamo"
+"Porta, Guglielmo della"
+"Porthaux, Dominique Antony"
+Pottier and Stymus Manufacturing Company
+"Poussin, Nicolas"
+"Powers, Hiram"
+"Pratt, Matthew"
+"Prendergast, Maurice Brazil"
+"Price, William Lightfoot"
+Prince Lu
+"Prince, Richard"
+"Proctor, Alexander Phimister"
+"Prutscher, Otto"
+QIAN XUAN
+QU DING
+Qasim ibn 'Ali
+"Raimondi, Marcantonio"
+"Ramírez, Manuel"
+Raphael (Raffaello Sanzio or Santi)
+"Ratel, Stanislas"
+"Rauschenberg, Robert"
+"Ray, Charles"
+Reboux Caroline
+Redlin Michel
+"Reiff, Jacob"
+Rembrandt (Rembrandt van Rijn)
+"Remington, Frederic"
+"Renoir, Auguste"
+"Revere, Paul, Jr."
+"Reynolds, Joshua, Sir"
+"Ribera, Jusepe de (called Lo Spagnoletto)"
+"Richards, William Trost"
+"Richters, Hendrik"
+"Ridolfi, Carlo"
+Riemenschneider Tilman
+"Riesener, Jean Henri"
+"Ringgold, Faith"
+Riza-yi `Abbasi
+"Robbia, Andrea della"
+"Robert, Louis-Rémy"
+"Roberts, David"
+"Roché, H. P."
+"Rodin, Auguste"
+"Rodríguez Juárez, Juan"
+"Roentgen, David"
+Rogier van der Weyden
+"Rohde, Gilbert"
+"Rood, Ogden Nicholas"
+Rose Joseph
+"Rosenquist, James"
+Rosenstein Nettie
+Rossberg Herman
+"Rossellino, Antonio"
+"Rossetti, Dante Gabriel"
+"Rossi, Giovanni Giacomo De"
+"Rota, Giovanni"
+"Roth, Heinrich"
+"Rothko, Mark"
+"Rousseau, Henri (le Douanier)"
+"Roux, Alexander"
+"Rovner, Michal"
+Royal Asiatic Society
+Royal Workshops at Greenwich
+"Rubens, Peter Paul"
+"Ruff, Thomas"
+"Ruhlmann, Émile-Jacques"
+"Ruisdael, Jacob van"
+"Ruscelli, Girolamo (Alessio Piemontese)"
+"Rush, William"
+Rébè
+"Régamey, Félix"
+"Rémond, Pierre"
+"Saarinen, Eliel"
+Saint Laurent Yves
+"Saint Laurent Yves, Paris"
+"Saint-Gaudens, Augustus"
+Salerno Editrice
+Salvioni
+"Sander, August"
+Sant'Angelo Giorgio
+"Sargent, John Singer"
+"Sarto, Andrea del (Andrea d'Agnolo)"
+"Sax, Charles Joseph"
+"Scherer, Georg Henrich"
+Schiaparelli Elsa
+"Schiele, Egon"
+"Schmidt, Jacob"
+Scholte
+"Schongauer, Martin"
+Schramberg Majolica Factory
+"Schrenck von Nozing, Jacob"
+"Schroll, A."
+"Schuech, Israel"
+"Searle, William"
+"Seeley, George H."
+"Sellas, Matteo"
+"Serlio, Sebastiano"
+Sesson Shūkei
+"Seurat, Georges"
+Shah Quli
+Shaykh Zada
+"Sheeler, Charles"
+"Sheraton, Thomas"
+"Sherman, Cindy"
+"Signac, Paul"
+"Siloe, Gil de"
+"Silve, David"
+Simca Print Artists Inc.
+Simier
+Sioux
+"Smibert, John"
+"Smith, David"
+"Smith, John Rubens"
+"Smithson, Robert"
+"Soligny, Eugene J."
+"Sottsass, Ettore"
+"Soudbinine, Séraphin"
+"Soufflot, Jacques Germain"
+Southworth and Hawes
+"Southworth, Albert Sands"
+"Sparre, Baron de"
+Spaulding and Company
+"Spranger, Bartholomeus"
+"Stazio, Abbondio"
+"Steen, Jan"
+"Steichen, Edward J."
+"Steinert, Otto"
+Stephens John Lloyd
+"Stiegel, Henry William"
+"Stieglitz, Alfred"
+"Still, Clyfford"
+"Stimmer, Tobias"
+"Story, William Wetmore"
+"Stradivari, Antonio"
+"Strahan, Edward"
+"Strand, Paul"
+"Struth, Thomas"
+"Stuart, Gilbert"
+Studio 65
+"Sugimoto, Hiroshi"
+Sukemitsu of Bizen
+"Sully, Thomas"
+Sulpicia
+Sultan Muhammad
+Sultan Muhammad Nur
+Sultan Murad III
+Suzi
+"Sweerts, Michiel"
+Sèvres Manufactory
+"Tachaux, Daniel"
+"Talbot, William Henry Fox"
+"Tanner, Henry Ossawa"
+"Targee, John"
+Tarnowski Jan and Valeria Count and Countess
+Tarporley Painter
+"Taylor, I. & J."
+Tecchler David
+Teijo Goto
+"Tekelü, Ahmed"
+"Tencalla, Carpoforo Mazzetti"
+Teng Yeohlee
+"Tessier, Louis"
+The Limbourg Brothers
+Thibault Girard
+"Thiout, Antoine"
+"Thiroux d'Arconville, Marie Geneviève Charlotte Darlus"
+"Thomas, Auguste H."
+"Thomassin, Henri Simon"
+Tielke Joachim
+"Tiepolo, Giovanni Battista"
+"Tiepolo, Giovanni Domenico"
+Tiffany & Co.
+Tiffany Glass and Decorating Company
+"Tiffany, Louis Comfort"
+"Tindale, Thomas & Harriet R."
+"Tinguely, Jean"
+"Tissot, Jean-Claude"
+Titian (Tiziano Vecellio)
+"Todini, Michele"
+Toft Thomas
+Tong zhi tang
+"Toulouse-Lautrec, Henri de"
+"Tournachon, Adrien"
+Townley
+"Townsend, John"
+"Treviso, Girolamo da"
+"Trumbull, John"
+"Turner, Joseph Mallord William"
+Ugolino da Siena (Ugolino di Nerio)
+Umbo (Otto Umbehr)
+Ungaro Emanuel
+Unidentified Artist
+Unknown
+"Uzanne, Octave"
+Valentin de Boulogne
+Valentina
+"Vali, Mustafa ibn"
+"Vallotton, Félix"
+"Vallou-de-Villeneuve, Julien"
+Vandercruse Roger called Lacroix
+"Vanderlyn, John"
+Vasaro Giovanni Maria
+"Vasters, Reinhold"
+Velázquez (Diego Rodríguez de Silva y Velázquez)
+"Vermeer, Johannes"
+"Verona, Stefano da"
+"Veronese, Paolo (Paolo Caliari)"
+Versace Gianni
+"Vignola, Jacopo [Giacomo] Barozzi da"
+Viking Press
+"Vile, William"
+"Villon, Jacques"
+Vincennes Manufactory
+"Vionnet, Madeleine"
+Voboam Jean-Baptiste
+"Voiriot, Guillaume"
+"Voll, Georg"
+"Vollard, Ambroise"
+Voltaire
+"Vonnoh, Bessie Potter"
+"Vuillard, Édouard"
+Vuillaume Jean Baptiste
+Vuitton Louis
+WILCOX SILVER
+Walbaum Matthias
+"Wall, Jeff"
+Wang Hui
+"Wang, Fu"
+"Wang, Shifu"
+"Ward, John Quincy Adams"
+"Warhol, Andy"
+"Waring, J. B."
+"Washburn, Ives"
+Watanabe Junya
+"Watkins, Carleton E."
+"Watteau, Antoine"
+Webb Philip
+"Weber, Max"
+"Wedgwood and Sons, Josiah"
+"Wedgwood, Josiah"
+Weeks
+"Wesenbeke, Jacques de"
+"West, Benjamin"
+"Westmacott, Richard, Sir"
+"Westwood, J. O."
+"Westwood, Vivienne"
+"Whately, Thomas"
+"Whipple, John Adams"
+"Whistler, James McNeill"
+"White, Clarence H."
+"Whitehouse, James Horton"
+"Whittredge, Worthington"
+Wiener Werkstätte
+Wildsmith John
+"Wiles, Irving Ramsey"
+"Williamson, George Charles"
+"Wilton, Joseph"
+"Winogrand, Garry"
+"Winslow, Edward"
+"Wood, Grant"
+"Woodman, Francesca"
+Woolnough Charles W.
+Workshop of Biduinus
+"Worth, Charles Frederick"
+"Worth, House of"
+"Wright, Frank Lloyd"
+Wu Bin
+"Wyatt, Matthew Digby Sir"
+Yale University Press
+"Yamamoto, Yohji"
+Yasumitsu
+"Zeisel, Eva"
+"Zick, Januarius"
+Zlan of Belewale
+"Zuccaro, Taddeo"
+"Zurbarán, Francisco de"
+"de Forest, Lockwood"
+"de Frías, Joseph"
+de Liège Jean
+"de Meyer, Adolf"
+de Perefixe Hardouin
+"de Querlon, Anne Gabriel Meusnier"
+de Touyl Jean
+de Werve Claus
+del Tasso
+"van der Stockt, Vranke"
+"von Hagenau, Nikolaus"
+"von Winterthur, Heinrich Heid"
+Érard
+‘Umar ibn Yusuf ibn ‘Umar ibn ‘Ali ibn Rasul al-Muzaffari

--- a/scripts/output/met_artwork/met_artists_unique.csv
+++ b/scripts/output/met_artwork/met_artists_unique.csv
@@ -1,1162 +1,1160 @@
 artist
 'Abd al-Qadir Hisari
 'Abdullah ibn al-Fadl
-"Abbott, Berenice"
-"Abels, Ludwig"
+A. A. Hébrard
+A. C. Glassgold
+A. H. Davenport
+A. Hepplewhite & Co.
+A. Schroll
+Aaron Douglas
+Abbondio Stazio
 Abu'l Qasim Firdausi
 Achilles Painter
-"Adam, Robert"
-"Adamson, Robert"
-"Adhikari, Murari"
-"Adrian, Gilbert"
-Adrover Miguel
+Adam Fuss
+Adolf de Meyer
+Adolphe Braun
+Adriaen van Ostade
+Adrien Tournachon
 "Aetna Silkscreen Products, Inc."
-"Aguado de las Marismas, Onésipe"
-Al-Sufi `Abd al-Rahman
-"Albers, Josef"
-"Alembert, Jean Le Rond d'"
+Ahmad ibn al-Suhrawardi al-Bakri
+Ahmed Tekelü
+Albert Bierstadt
+Albert Marquet
+Albert Sands Southworth
+Alberto Giacometti
+Alberto Lavezzola
+Albrecht Altdorfer
+Albrecht Dürer
+Alessandro Mazzinelli
+Alexander Calder
+Alexander Gardner
 Alexander McQueen
-"Alexandre, Arsène"
-"Alken, Sefferin"
-"Alpert, Richard"
-"Altdorfer, Albrecht"
+Alexander Phimister Proctor
+Alexander Roux
+Alexandre Pere & Fils
+Alexandre-Jean Oppenordt
+Alfred Stieglitz
+Alvin Langdon Coburn
 Amasis Painter
-Amati Andrea
-"Amelung, John Frederick"
-American Flint Glass Manufactory 
+Ambroise Vollard
+Ambrosius Gemlich
+Amedeo Modigliani
+American Flint Glass Manufactory
 American Pottery Manufacturing Company
 American Tobacco Company
 American Union of Decorative Artists and Craftsmen
 Amir Khusrau Dihlavi
-"Amman, Jost"
-"Anatsui, El"
 Andokides
 Andokides Painter
-"Andreoli, Giorgio Maestro"
-"Andrews, Benny"
-"Andrews, William Loring"
-Angas George French
+Andrea Amati
+"Andrea Briosco, called Riccio"
+Andrea Mantegna
+Andrea Palladio
+Andrea del Sarto (Andrea d'Agnolo)
+Andrea della Robbia
+Andreas Gursky
+Andreas Naeplaesnigg
+Andrew Bush
+André Charles Boulle
+André Courrèges
+André Derain
+André Kertész
+Andy Warhol
+Angelo Mannello
+Anish Kapoor
+Anna Maria Garthwaite
+Anne Gabriel Meusnier de Querlon
+Annibale Carracci
 Anonymous
 Anonymous Flemish weavers
-"Anshutz, Thomas"
-"Antico (Alari Bonacolsi, Pier Jacopo)"
-"Apianus, Georg and Petrus"
-"Apianus, Petrus"
-Appleton & Co.
-"Appleton, Thomas"
+Anselm Kiefer
+Anthony Caro
+Anthony van Dyck
+Antico (Pier Jacopo Alari Bonacolsi)
+Antoine Humblot
+Antoine Joseph Dézallier d'Argenville
+Antoine Thiout l'aîné
+Antoine Watteau
+Anton Mozart
+Antonio Canova
+Antonio Pollaiuolo
+Antonio Rossellino
+Antonio Stradivari
 "Apvd Gvlielmvm, svb scvto veneto"
-"Arbus, Diane"
-"Argens, Jean-Baptiste de Boyer, marquis d'"
-"Ariosto, Ludovico"
-Armani Giorgio
-"Armitt, Joseph"
-Arndts Johan
+"Armand Colin et Cie., Éditeurs"
+Arnold Böcklin
 Arnold Seneuse
-"Atget, Eugène"
+Arshile Gorky
+Arsène Alexandre
+Ascanio Condivi
+Asher Brown Durand
 Athabascan Family
-"Audran, Girard"
-"Auguste, Charles, marquis de La Fare"
-"Avery, Milton"
-"Avery, Samuel Putnam, Sr."
-"Avril, Paul"
-"Bacon, Francis H."
-"Bacot, Edmond"
+Athanasius Kircher
+Aubrey Vincent Beardsley
+August Sander
+Auguste Edouart
+Auguste H. Thomas
+Auguste Renoir
+Auguste Rodin
+Augustin Pajou
+Augustus Saint-Gaudens
 Badi' al-Zaman ibn al-Razzaz al-Jazari
 "Bakewell, Page & Bakewell"
-"Bakst, Léon"
-"Baldung, Hans (called Hans Baldung Grien)"
-"Baldus, Édouard"
-Balenciaga House of
-"Balenciaga, Cristobal"
+Baldassare Tommaso Peruzzi
+Balthasar Permoser
 Balthus (Balthasar Klossowski)
 Bamen Tomotsugu
-"Baranik, Rudolf"
+Baptiste Pellerin
+Barak Norman
+Barbara Hepworth
+Barbara Hodgson
 Barbou
-"Baronzio, Giovanni"
-Barrie
-"Barry, and Son Joseph B."
+Baron Jean-Baptiste-Louis Gros
+Baron de Sparre
+Bartholomeus Spranger
 Bartolo di Fredi
-"Bartolomeo, Fra (Bartolomeo di Paolo del Fattorino)"
+Bartolomeo Cristofori
+Bartolomé Estebán Murillo
 Basawan
-"Bassano, Jacopo (Jacopo da Ponte)"
-"Bastien-Lepage, Jules"
+Basilio Onofri
 Bastis Master
-Baudoin Joseph-François-Xavier
 Baudouin
-"Bauer, Johann Michael"
-"Baur, Daniel"
-"Baziotes, William"
-"Bearden, Romare"
-"Beardsley, Aubrey Vincent"
-"Beaux, Cecilia"
-"Beckmann, Max"
 Beissbarth & Hoffmann
-"Belleau, Remy"
-"Bellini, Giovanni"
-"Bellows, George"
-"Belter, J. H."
-"Belzoni, Giovanni Battista"
-"Benbridge, Henry"
 Benedetto da Maiano
-"Bening, Simon"
-"Bennett, John"
-"Bensley, Thomas"
-"Benton, Thomas Hart"
+Benjamin West
+Benny Andrews
+Bento de Moura Portugal
 Benvenuto di Giovanni
-"Berain, Jean"
+Berenice Abbott
 Berlin Painter
+Bernard Palissy
 Bernard Quaritch Ltd.
-"Bernard, Léopold"
-Berners Juliana
-"Bernieres, de"
-"Bernini, Gian Lorenzo"
-"Bernini, Pietro"
+Bernard van Orley
+Bernardo Daddi
+Bessie Potter Vonnoh
 Bhawani Das
 Biblioteca Nazionale Marciana
-"Bidermann, Samuel"
-"Biennais, Martin-Guillaume"
-"Bierstadt, Albert"
+Biduinus
 Bihzad
-"Bingham, George Caleb"
-"Bishop, Heber R."
+Bill Blass
+Bill Brandt
 Black Emergency Cultural Coalition and Artists and Writers Protest Against the War in Vietnam
 Black Stone Press
-"Blackburn, Joseph"
-"Blaeu, Johannes"
-"Blake, George Henry"
-"Blanc, Charles"
-"Blass, Bill"
-Blemly William Ignatius
-Blockley Thomas
-"Blume, Peter"
-"Boccaccio, Giovanni"
-"Boccalini, Traiano"
-"Boccioni, Umberto"
-Boch Jean
-"Boekhout, Thomas Coenraet"
-"Boileau Despréaux, Nicolas"
-"Boito, Camillo"
-"Bonheur, Rosa"
-"Bonnard, Pierre"
-"Bononome, Giuseppe"
 Bonwit Teller & Co.
-"Borch, Gerard ter, the Younger"
-"Borchardt, Ludwig"
-"Borcht, Peeter van der"
-Boslwert A.
-Boston and Sandwich Glass Company
-"Botero, Fernando"
+Boston & Sandwich Glass Company
 Botticelli (Alessandro di Mariano Filipepi)
-"Bouchard, Giovanni"
-"Boucher, François"
-"Bouillat père, Edme François"
-"Boulle, André Charles"
-"Bourgeois, Louise"
-Bousch Valentin
-"Boutet, Nicholas-Noël"
-"Bozerian, Jean Claude"
-"Brady, Mathew B."
-Brainerd Ira Hutchinson
-"Brancusi, Constantin"
-Brandely Jean
-"Brandt, Bill"
-"Brandt, Marianne"
-"Braque, Georges"
 Brassaï
-"Braun, Adolphe"
-"Bret, M. (Antoine)"
-"Briani, Girolamo"
 Briasson
-"Briosco, Andrea, called Riccio"
 Bronzino (Agnolo di Cosimo di Mariano)
-"Broodthaers, Marcel"
-"Brotto, Carlo Bertoncello"
-"Brown, W. and O'Neil A."
-"Bruegel, Pieter, the Elder"
-"Brueghel, Jan, the Elder"
-"Brugghen, Hendrick ter"
-"Brun, J. C. A."
-Buli Master
-Bunsen Franz Peter
-"Buonanni, Filippo"
-"Burne-Jones, Edward, Sir"
-"Bush, Andrew"
-Bushell Stephen Wootton Dr.
-"Bustamante, Jean-Marc"
-"Bustelli, Franz Anton"
+"Buli Master, possibly Ngongo ya Chintu (Hemba, ca. 1810-1870)"
 Byrdcliffe Arts and Crafts Colony
-"Böckler, Georg Andreas"
-"Böcklin, Arnold"
-"Calder, Alexander"
-"Callahan, Harry"
+C. Liger
+Caleb Gardner
 Callot Soeurs
 Cambridge University Press
-"Cameron, Julia Margaret"
-"Camilli, Camillo"
-"Campin, Robert"
+Camille Corot
+Camille Pernon
+Camillo Boito
+Camillo Camilli
 Canaletto (Giovanni Antonio Canal)
-"Canova, Antonio"
 Caravaggio (Michelangelo Merisi)
-"Carducho, Vincente"
-"Carlin, Martin"
-"Caro, Anthony"
-"Carpaccio, Vittore"
-"Carpeaux, Jean-Baptiste"
-"Carpi, Ugo da"
-"Carracci, Annibale"
-"Carradori, Francesco"
-"Carrington, Leonora"
-"Cassatt, Mary"
-"Castiglione, Giovanni Benedetto (Il Grechetto)"
+Carleton E. Watkins
+Carlo Bertoncello Brotto
+Carlo Gregori
+Carlo Ridolfi
+Caroline Reboux
+Carpoforo Mazzetti Tencalla
+Caspar David Friedrich
 Catholic Church
-"Cesnola, Luigi Palma di"
+Cecilia Beaux
 Chaignieau
 Chakalte'
-"Champigneulle, Jacques-Charles"
-"Chanel, Gabrielle ""Coco"""
-"Chanel, House of"
-"Chardin, Jean Siméon"
-"Chase, William Merritt"
-"Chauvassaignes, Franck-François-Genès"
-"Chauvet, Jules Adolphe"
-"Chevreul, Michel Eugène"
+Chand Muhammad
+Charles Antoine Jombert
+"Charles Auguste, marquis de La Fare"
+Charles B. Falls
+Charles Blanc
+Charles Caryl Coleman
+Charles Cromwell Ingham
+Charles Demuth
+Charles Dominique Joseph Eisen
+Charles Frederick Worth
+Charles James
+Charles Joseph Sax
+Charles Le Brun
+Charles Martel
+Charles Morice
+Charles Nicolas Cochin I
+Charles Nicolas Cochin II
+Charles Nicolas Dodin
+Charles Nègre
+Charles Percier
+Charles Ray
+Charles Rennie Mackintosh
+Charles Sheeler
+Charles W. Woolnough
+Charles Willson Peale
+Charles-Guillaume Diehl
+Charles-Honoré Lannuier
+Charles-Paul Landon
 Chez Desnos
 Chez Jubert
-"Chippendale, Thomas"
-"Chirico, Giorgio de"
+Childe Hassam
 Chitarman
-"Chizzola, Luigi"
-"Choiselat, Marie-Charles-Isidore & Stanislas Ratel"
-"Christus, Petrus"
-"Church, Frederic Edwin"
-Clark John
+Chongyi Nie
+Christian Dior
+Christian Frederick Martin
+Christian Kintzing
+Christian Lacroix
+Christoph Murer
+Christopher Dresser
+Chuck Close
+Cindy Sherman
+Claes Oldenburg
+Claire McCardell
+Clarence H. White
+Claude Duflos
 Claude Laurent
 Claude Lorrain (Claude Gellée)
+Claude Monet
+Claudia Cohen
+Claus de Werve
 Clodion (Claude Michel)
-"Close, Chuck"
 Clousier
-Cobb John
-"Coburn, Alvin Langdon"
-"Cochin, Charles Nicolas, I"
-"Cochin, Charles Nicolas, II"
-"Coggeshall, Patty"
-"Cohen, Claudia"
-"Cole, Thomas"
-"Coleman, Charles Caryl"
-"Colin et Cie., Éditeurs"
-"Collombat, Jacques"
-"Colt, Samuel"
+Clyfford Still
 Comme des Garçons
-Compagnie des libraires associés
-"Condivi, Ascanio"
-"Constable, John"
-"Conti, Giovan Stefano"
+Constantin Brancusi
 "Convent of Saint Joseph-de-la-Providence, Paris"
-"Copley, John Singleton"
-"Corot, Camille"
-"Cour, Jean"
-"Courbet, Gustave"
-"Courrèges, André"
+Cornelius Kierstede
+Count Anthony Hamilton
+Count Jan and Countess Valeria Tarnowski
 Courtois frères
-"Cousin, Jean, the Elder"
-"Cranach, Lucas, the Elder"
-"Crawford, Thomas"
-Cristofori Bartolomeo
-Croly George Rev.
-"Cropsey, Jasper Francis"
-"Cross, Henri-Edmond"
-"Cuntz, Steffan"
-"Curran, John T."
-"Curry, John Steuart"
-Curtius Ernst
-"Custos, Dominicus"
-"Cuvelier, Eugène"
-"Cézanne, Paul"
-"Daddi, Bernardo"
-"Dalí, Salvador"
-"Dapper, Olfert"
-"Daumier, Honoré"
-"Davenport, A. H."
-"David, Gerard"
-"David, Jacques Louis"
-"Davis, Joseph H."
-"Davis, Stuart"
-"De Kooning, Willem"
+Cristobal Balenciaga
+D. Appleton & Co.
+Daniel Baur
+Daniel Chester French
+Daniel Pabst
+Daniel Tachaux
+Dante Gabriel Rossetti
+Dard Hunter
+David Hammons
+David II Pfau
+David Johnson
+David Lucas
+David Octavius Hill
+David Roberts
+David Roentgen
+David Silve
+David Smith
+David Tecchler
+David-Pierre Giottino Humbert de Superville
 De Vinne Press
-"Deburau, Jean-Charles"
-"Degas, Edgar"
-"Delacroix, Eugène"
-"Delaune, Étienne"
-"Demuth, Charles"
+Decimus Junius Juvenal
+Denis Diderot
 Denis de Sainte-Marthe
-"Dennis, Thomas"
-"Denon, Dominique Vivant Baron"
-"Derain, André"
-"Desplaces, Louis"
-"Deutschmann, Joseph"
-"Dewing, Thomas Wilmer"
-"Diderot, Denis"
-"Didot, François Ambroise"
-"Didot, Pierre l'ainé"
-Diehl Charles-Guillaume
-"Dijon, V."
-"Diodati, Ottaviano"
-"Dior, Christian"
-"Dior, House of"
-"Dittrich, Edith"
-"Dix, Otto"
-"Dodin, Charles Nicolas"
+Diane Arbus
+Diego de Pesquera
+Docteur (Louis) Martin
+Domenico Martinelli
+Dominicus Custos
+Dominique Antony Porthaux
 Donatello
-"Doucet, Jacques"
-"Douglas, Aaron"
-Drecoll
-"Dresser, Christopher"
-"Drouart, Jean"
+Dorothea Lange
+Dr. Stephen Wootton Bushell
+Drécoll
 Du-Art Displays
-"Dubuffet, Jean"
 Duccio di Buoninsegna
-"Duchamp, Marcel"
-"Duflos, Claude"
-"Dugourc, Jean Démosthène"
-"Dunand, Jean"
-"Dunn, Henry Treffry"
-"Dupas, Jean"
-"Duplessis, Jean-Claude"
+Duncan Phyfe
 Durand
-"Durand, Asher Brown"
-"Dwiggins, William Addison"
-"Dyck, Anthony van"
-"Dézallier d'Argenville, Antoine Joseph"
-"Dürer, Albrecht"
-"Eakins, Thomas"
-"Earl, Ralph"
-"Edmonds, Francis William"
-"Edouart, Auguste"
-"Eisen, Charles Dominique Joseph"
-Elevated Tone Workshop
-Elseviers
-"Emmoser, Gerhard"
-"Enríquez, Nicolás"
+"E. Plon, Nourrit et Cie."
+Eastman Johnson
+Edgar Degas
+Edith Dittrich
+Edme François Bouillat père
+Edmond Bacot
+Edward Hicks
+Edward Hopper
+Edward J. Steichen
+Edward Molyneux
+Edward Strahan (Earl Shinn)
+Edward Winslow
+Egon Schiele
+El Anatsui
+El Greco (Domenikos Theotokopoulos)
+El Lissitzky
+"Elevated Tone Workshop, Guangzhou (Canton)"
+Elie Gervais
+Eliel Saarinen
+Elizabeth Murray
+Ellsworth Kelly
+Elsa Schiaparelli
+Emanuel Leutze
+Emanuel Ungaro
+Emile Gaudissard
+Emmanuel Frémiet
+Emperor Huizong
+Enrico Malato
 Epimenes
+Erastus Dow Palmer
 Eretria Painter
-"Ernst, Max"
-"Ertel, Giacomo (Jacob)"
-"Esherick, Wharton"
-Esposito Giosue
-"Estienne, Robert"
-"Eugenico, Niccolò"
+Ernst Curtius
+Ettore Sottsass
+Eugene J. Soligny
+Eugène Atget
+Eugène Cuvelier
+Eugène Delacroix
 Euphiletos Painter
-"Evans, Walker"
+Eva Zeisel
 Exekias
-"Eyck, Jan van"
 Ezra
+F. Scholte
 Factory Additions
-"Faigenbaum, Patrick"
-"Falls, Charles B."
-"Fannière, François-Auguste"
-"Fannière, François-Joseph-Louis"
+Faith Ringgold
 Farid al-Din `Attar
-"Farrer, Henry"
 Farrukh ibn `Abd al-Latif
-Fath House of Jacques
-Fath Jacques
-"Feininger, T. Lux"
-"Fenton, Roger"
-"Fernández, Francisco"
-Ferragamo Salvatore
-"Ferriss, Hugh"
-"Fielding, Theodore Henry Adolphus"
-"Finlay, Hugh"
-"Finlay, John"
-"Fisher, Robert"
-"Fitch, Julia Ann"
-"Fletcher, Thomas"
-"Foggini, Giovanni Battista"
-"Folengo, Theophilo"
-"Fontana, Giovanni Battista"
-Ford Tom
-"Fort, Louis"
+Ferdinand Hofmann
+Ferdinando Ongania
+Fernand Léger
+Fernando Botero
+Filippino Lippi
+Filippo Buonanni
+Filippo Negroli
+Fitz Henry Lane (formerly Fitz Hugh Lane)
 Fortuny
-"Fortuny, Mariano"
-"Fouquet, Georges"
-"Fouquet, Jean"
-Fourteen identified German (Augsburg) goldsmiths and other Germa
-"Fragonard, Jean Honoré"
-Franceschi Francesco de'
+Fourteen identified German (Augsburg) goldsmiths and other German artisans; Japanese (Imari) porcelain maker
+Fra Bartolomeo (Bartolomeo di Paolo del Fattorino)
+Fra Filippo Lippi
+Francesca Woodman
+Francesco Carradori
+Francesco Guardi
+Francesco de' Franceschi
 Francesco di Giorgio Martini
-"Frankl, Paul T."
+Francesco di Marco Marmitta da Parma
+Francis H. Bacon
+Francis Malthus
+Francis William Edmonds
+Francisco Fernández
+Francisco López
+Francisco Martínez
+Francisco de Zurbarán
+Franck-François-Genès Chauvassaignes
+Frank Lloyd Wright
+Frans Hals
+Franz Anton Bustelli
+Franz Peter Bunsen
+Franz Xaver Messerschmidt
+François Ambroise Didot
+François Boucher
+François Jean Gabriel de La Porte du Theil
+François Thomas Germain
+François de Paule Latapie
+François de Salignac de La Mothe-Fénelon
+François-Auguste Fannière
+François-Honoré-Georges Jacob-Desmalter
+François-Joseph-Louis Fannière
+Frederic Edwin Church
+Frederic Remington
+Frederick William MacMonnies
 French
-"French, Daniel Chester"
-"Freud, Lucian"
-"Friedrich, Caspar David"
-"Froehner, Wilhelm"
-Frémiet Emmanuel
+Fu Wang
 Fulper Pottery Company
-"Furman, Warner Williams Sarah"
-"Fuss, Adam"
-"Fénelon, François de Salignac de La Mothe-"
-GONG XIAN
-"Gahn, Johann Benedikt"
-"Gainsborough, Thomas"
+Félix Régamey
+Félix Vallotton
+Félix-Jacques-Antoine Moulin
+"Gabrielle ""Coco"" Chanel"
 Galeria Arte Global
-"Gallet, George"
-Galliano John
 Ganda
-"Gardiner, Sidney"
-"Gardner, Alexander"
-"Gardner, Caleb"
 Garion
-"Garnier, Jules"
-"Garofolo, Girolamo"
-"Garthwaite, Anna Maria"
-"Gaucherel, Léon"
-"Gaudissard, Emile"
-"Gauguin, Paul"
-Gaultier Jean Paul
-"Gemlich, Ambrosius"
-"Gerhaert von Leyden, Niclaus"
-"Gericault, Théodore"
-"Germain, François Thomas"
-"Gernreich, Rudi"
-Gervais Elie
-"Giacometti, Alberto"
+Garry Winogrand
+Gaston Lachaise
+Georg Andreas Böckler
+Georg Henrich Scherer
+Georg Voll
+Georg and Petrus Apianus
+George Barrie
+George Bellows
+George Caleb Bingham
+George Charles Williamson
+George E. Ohr
+George Frederick Kunz
+George French Angas
+George Gallet
+George Henry Blake
+George Inness
+George Jakob Hunzinger
+George P. A. Healy
+George Seeley
+Georges Braque
+Georges Fouquet
+Georges Hoentschel
+Georges Jacob
+Georges Seurat
+Georges de La Tour
+Georgia O'Keeffe
+Gerard David
+Gerard ter Borch the Younger
+Gerhard Emmoser
+Gertrude Käsebier
+Giacomo (Jacob) Ertel
 Giambologna
+Gian Lorenzo Bernini
 Gianni Versace
-"Gibbs, Josiah W. (Josiah Willard)"
-"Gifford, Sanford Robinson"
-Gilbert John
-"Gilbert, S. & T."
-"Gilles, Pierre"
+Gil de Siloe
+Gilbert Adrian
+Gilbert Rohde
+Gilbert Stuart
+Gilles Joubert
+Giorgio Armani
+Giorgio de Chirico
+Giorgio di Sant'Angelo
+Giosue Esposito
 Giotto di Bondone
+Giovan Stefano Conti
+Giovanni Baronzio
+Giovanni Battista Belzoni
+Giovanni Battista Foggini
+Giovanni Battista Fontana
+Giovanni Battista Pacetti
+Giovanni Battista Pigna
+Giovanni Battista Piranesi
+Giovanni Battista Tiepolo
+Giovanni Bellini
+Giovanni Benedetto Castiglione (Il Grechetto)
+Giovanni Boccaccio
+Giovanni Bouchard
+Giovanni Domenico Tiepolo
+Giovanni Giacomo De Rossi
+Giovanni Grancino
+Giovanni Mynardo (Jean Ménard)
+Giovanni Paolo Lomazzo
+Giovanni Paolo Panini
+Giovanni Pisano
+Giovanni Rota
 Giovanni di Paolo (Giovanni di Paolo di Grazia)
-"Giuntini, Vincenzo"
-Givenchy House of
-"Givenchy, Hubert de"
-"Glackens, William James"
-Glassgold A. C.
-"Gogh, Vincent van"
+Girard Audran
+Girard Thibault
+Girolamo Briani
+Girolamo Garofolo
+Girolamo Porro
+Girolamo Ruscelli (Alessio Piemontese)
+Girolamo da Treviso
+Giuliano da Maiano
+Giuseppe Bononome
+Giuseppe Passeri (Passari)
+Gong Xian
+Gordon Matta-Clark
 Gorham Manufacturing Company
-"Gorky, Arshile"
 Gotō Yūjō
-"Goullons, Jacques"
 Govardhan
 Goya (Francisco de Goya y Lucientes)
-"Graf, Urs"
-"Graham, John"
-Grancino Giovanni
-"Grand-Carteret, John"
-Grecke Johan Adolph
-"Greco, El (Domenikos Theotokopoulos)"
-"Greene, John Beasley"
-"Gregori, Carlo"
-Grenser H.
-"Greuze, Jean-Baptiste"
-Grittel Èmile
-"Grooms, Red"
-"Gros, Jean-Baptiste-Louis"
-"Groto, Luigi"
+Grant Wood
 Group of Boston 00.348
-Grouwels Lodewijck
-"Grès, Madame"
-"Guardi, Francesco"
 Gucci
 Guercino (Giovanni Francesco Barbieri)
 Gufram
+Guglielmo della Porta
+Guillaume Voiriot
 Guo Xi
-"Gursky, Andreas"
-"Guston, Philip"
-"Guy, Seymour Joseph"
-"Guélard, J. B."
-"Gérôme, Jean-Léon"
-HAN GAN
-HUANG TINGJIAN
-Haas Johann Wilhelm
-Habiballah
+Gustav Klimt
+Gustave Courbet
+Gustave Le Gray
+H. Grenser
+H. Harris
+H. P. Roché
+Habiballah of Sava
 Hafiz
-"Haghe, Louis"
-"Halder, Jacob"
 Hallé
-"Hals, Frans"
 Halston
-"Hamilton, Anthony, Count"
-"Hammons, David"
-"Hannock, Stephen"
+Han Gan
+Hans Baldung (called Hans Baldung Grien)
+Hans Heinrich III Pfau
+Hans Holbein the Younger
+Hans Leinberger
+Hans Memling
 Hans of Landshut
+Hardouin de Perefixe
 Hardy-Mennil
 Harper & Brothers
-Harris H.
-"Hartley, Marsden"
-"Hassam, Childe"
-"Hathaway, Rufus"
+Harry Callahan
 Hatifi
-"Hauser, Hermann"
-"Hauslaib, Lorenz"
-"Hawes, Josiah Johnson"
-Hayashi Kodenji
-"Hayashi, Tadamasa"
-"Heade, Martin Johnson"
-"Healy, George P. A."
 Heavenly Monkey
-"Heiglen, Johann Erhard"
-Heinrich of Constance Master
-"Helmschmid, Kolman"
-"Henle, Jan"
-"Hepplewhite, A. & Co."
-"Hepworth, Barbara"
+Heber R. Bishop
+Heinrich Heid von Winterthur
+Heinrich Roth
+Hendrick ter Brugghen
+Hendrik Richters
+Henri Matisse
+Henri Michaux
+Henri Rousseau (le Douanier)
+Henri Simon Thomassin
+Henri de Toulouse-Lautrec
+Henri-Edmond Cross (Henri-Edmond Delacroix)
+Henri-Jean-Louis Le Secq
+Henry Benbridge
+Henry Farrer
+Henry Ossawa Tanner
+Henry Treffry Dunn
+Henry Wadsworth Longfellow
+Henry William Stiegel
+Herman Rossberg
+Hermann Hauser
+Hermon Atkins MacNeil
 Herter Brothers
-"Hey, Jean (called Master of Moulins)"
-"Hicks, Edward"
 Hill and Adamson
-"Hill, David Octavius"
-"Hine, Lewis"
+Hiram Powers
+Hiroshi Sugimoto
 Hirschfeld Workshop
-"Hobcraft, John"
-"Hodgson, Barbara"
-"Hoentschel, Georges"
-"Hoffmann, Josef"
-Hofmann Ferdinand
-"Holbein, Hans, the Younger"
-"Holden, Richard"
-"Homer, Winslow"
-"Hooch, Pieter de"
-"Hooghe, Romeyn de"
-"Hopper, Edward"
-"Houdon, Jean Antoine"
+Honoré Daumier
+Horace Pippin
 Houghton Mifflin Company
-"Houry, Laurent Charles d'"
+House of Balenciaga
+House of Chanel
+House of Dior
+House of Givenchy
+House of Jacques Fath
+House of Lanvin
+House of Paquin
+House of Patou
+House of Worth
+Huang Tingjian
+Hubert de Givenchy
+Hugh Ferriss
+Hugh Finlay
 Hugo Boss
-Huizong Emperor
+Hugues Le Roux
 Hukin & Heath
-"Humbert, de Superville David-Pierre Giottino"
-"Humblot, Antoine"
-"Hunter, Dard"
-"Hunzinger, George Jakob"
-HÉBRARD A. A.
-"Hérissant, La Veuve"
-"Ibn al-Suhrawardi al-Bakri, Ahmad"
-Imperial Armory
+Hélio Oiticica
+I. & J. Taylor
+"Imperial Armory, Tula (south of Moscow), Russia"
 "Imperial Porcelain Manufactory, St. Petersburg"
 Imprimerie de Testu
-Ince William
 Ince and Mayhew
-"Ingham, Charles Cromwell"
-"Ingres, Jean Auguste Dominique"
-"Inness, George"
+"International Silver Company, Wilcox Silver Plate Company Division (Meriden, Connecticut)"
+Ira Hutchinson Brainerd
+Irving Penn
+Irving Ramsey Wiles
+Isamu Noguchi
 Ishiguro Masayoshi
+Israel Schuech
 Italian
 "Italian, Siena"
-Itoh Takuo
+Ives Washburn
 Iwamoto Konkan
-"Iyetada, Saotome"
-Ja'far ibn Muhammad ibn `Ali
-"Jackson, Samuel"
-"Jacob, Georges"
-Jacob-Desmalter François-Honoré-Georges
-"Jacobs, Marc"
+J. B. Guélard
+J. B. Waring
+J. C. A. Brun
+J. C. Nimmo and Bain
+J. O. Westwood
+J. Pierpont Morgan
+Ja`far ibn Muhammad ibn `Ali
+Jackson Pollock
+Jacob Halder
+Jacob Kuntz
+Jacob Lawrence
+Jacob Reiff
+Jacob Schmidt
+Jacob Schrenck von Nozing
+Jacob van Ruisdael
 Jacometto (Jacometto Veneziano)
-"Jacques, Maurice"
-James Charles
+Jacopo Bassano (Jacopo da Ponte)
+Jacopo [Giacomo] Barozzi da Vignola
+Jacques Collombat
+Jacques Doucet
+Jacques Fath
+Jacques Germain Soufflot
+Jacques Goullons
+Jacques Louis David
+Jacques Neilson
+Jacques Villon
+Jacques de Wesenbeke
+Jacques-Charles Champigneulle
+James Horton Whitehouse
+James McNeill Whistler
+James Morisset
+James Peale
+James Rosenquist
+James Weldon Johnson
+Jan Brueghel the Elder
+Jan Henle
+Jan Steen
+Jan van Eyck
+Jan van Mekeren
+Januarius Zick
+Jasper Francis Cropsey
+Jasper Johns
+Jean Antoine Houdon
+Jean Auguste Dominique Ingres
+Jean Baptiste Vuillaume
+"Jean Baptiste de Boyer, marquis d'Argens"
+Jean Berain
+Jean Boch
+Jean Brandely
+Jean Claude Bozerian
+Jean Cour (or Court)
+Jean Cousin the Elder
+Jean Drouart
+Jean Dubuffet
+Jean Dunand
+Jean Dupas
+Jean Démosthène Dugourc
+Jean Fouquet
+Jean Henri Riesener
+Jean Hey (called Master of Moulins)
+Jean Honoré Fragonard
+Jean Le Rond d'Alembert
+Jean Lemoyen le Lorrain
+Jean Michel Moreau the Younger
+Jean Monnet
+Jean Paul Gaultier
+Jean Pucelle
+Jean Siméon Chardin
+Jean Tinguely
+Jean de La Fontaine
+Jean de Liège
+Jean de Touyl
+Jean-Baptiste Carpeaux
+Jean-Baptiste Greuze
+Jean-Baptiste Poquelin Molière
+Jean-Baptiste Voboam
+Jean-Charles Deburau
+Jean-Claude Duplessis
+Jean-Claude Tissot
+Jean-François Oeben
+Jean-Louis Lemoyne
+Jean-Léon Gérôme
+Jean-Marc Bustamante
+Jeanne Lanvin
+Jeff Wall
 Jeffrey & Co.
+Ji Eon Kang
+Joachim Patinir
+Joachim Tielke
+Joan Miró
+Johan Adolph Grecke
+Johan Arndts
+Johann Benedikt Gahn
+Johann Engelbert Noyse von Campenhouten
+Johann Erhard Heiglen
+Johann Gottlieb Kirchner
+Johann Michael Bauer
+Johann Wilhelm Haas
+Johann Wilhelm Oberlender (the Elder)
+Johannes Blaeu
+Johannes Vermeer
+John Adams Whipple
+John Beasley Greene
+John Bennett
+John Clark
+John Cobb
+John Constable
 John Devall & Co.
-"Johns, Jasper"
-"Johnson, David"
-"Johnson, Eastman"
-"Johnson, James Weldon"
-"Joly, Robert "
-"Jombert, Charles Antoine"
-"Jones, Owen"
-Joubert Gilles
-"Juvenal, Decimus Junius"
+John Finlay
+John Frederick Amelung
+John Frederick Kensett
+John Galliano
+John Gilbert
+John Graham
+John Grand-Carteret
+John H. Belter
+John Hobcraft
+John La Farge
+John Lloyd Stephens
+John Marin
+John Mayhew
+John Milton
+John Quincy Adams Ward
+John Rubens Smith
+John Singer Sargent
+John Singleton Copley
+John Smibert
+John Steuart Curry
+John T. Curran
+John Targee
+John Townsend
+John Trumbull
+John Vanderlyn
+John Wildsmith
+Josef Albers
+Josef Hoffmann
+Joseph Armitt
+Joseph B. Barry and Son
+Joseph Blackburn
+Joseph Deutschmann
+Joseph H. Davis
+Joseph Mallord William Turner
+Joseph Pons
+Joseph Rose
+Joseph Wilton
+Joseph de Frías
+Joseph-François-Xavier Baudoin
+Josiah Johnson Hawes
+Josiah W. (Josiah Willard) Gibbs
+Josiah Wedgwood
+Josiah Wedgwood and Sons
+Jost Amman
+Juan Martinez
+Juan Martínez Montañés
+Juan Rodríguez Juárez
+Jules Adolphe Chauvet
+Jules Bastien-Lepage
+Jules Garnier
+Julia Ann Fitch
+Julia Margaret Cameron
+Juliana Berners
+Julien Vallou de Villeneuve
+Junya Watanabe
+Jusepe de Ribera (called Lo Spagnoletto)
 Kamal Muhammad
-Kamali Norma
-"Kandinsky, Vasily"
-Kang Ji
 Kano Sansetsu
-"Kapoor, Anish"
-"Kaunitz-Rietberg, Prince Wenzel von"
-"Kelly, Ellsworth"
-"Kensett, John Frederick"
+Karl L. H. Müller
 Kephisodotos
-"Kertész, André"
-"Kiefer, Anselm"
-"Kierstede, Cornelius"
-"Kilburn, (or Kilbrunn) Lawrence"
-"Kim, Kwang Ju"
-Kintzing Christian
-Kirchner Athanasius
-Kirchner Johann Gottlieb
-"Klee, Paul"
+Kim Kwang Ju
 Kleihnans
-"Klein, William"
-"Klimt, Gustav"
-"Knoedler, M., & Co."
-Koyate Mamadou
-"Krasner, Lee"
-Kunitoshi Rai
-"Kuntz, Jacob"
-Kunz George Frederick
-"Käsebier, Gertrude"
-Kōrin
+Knud Lonberg-Holm
+Kodenji Hayashi
+Kolman Helmschmid
+Kunz Lochner
 L'Imprimerie Royale
-LEINBERGER HANS
-LIMOSIN LÉONARD
+L. H. Le Moine
 LIONARDO
-"La Farge, John"
-"La Fontaine, Jean de"
-"La Porte du Theil, François Jean Gabriel de"
-"La Tour, Georges de"
+La Compagnie des libraires associés
 La Veuve Besongne & Fils
-"Lachaise, Gaston"
-Lacroix Christian
-"Lalique, René-Jules"
-"Lambert, Michel"
-"Lamire, Leon"
-"Landon, Charles-Paul"
-"Lane, Fitz Henry"
-"Lange, Dorothea"
-Langenbucher Veit
+La Veuve Hérissant
 Langlois
-Langlois Peter
-"Lannuier, Charles-Honoré"
-"Lanvin, House of"
-"Lanvin, Jeanne"
-"Latapie, François de Paule"
-"Lavaur, M. (Guillaume de)"
-"Lavezzola, Alberto"
-"Lawrence, Jacob"
-"Lawrence, Thomas, Sir"
-"Le Bourgeois, Marin"
-"Le Bourgeois, Pierre"
-"Le Brun, Charles"
-"Le Gray, Gustave"
-"Le Moine, L. H."
-Le Roux Hugues
-"Le Secq, Henri-Jean-Louis"
-"Leary, Timothy"
-Lekeux Peter
-Lemoyen le Lorrain Jean
-Lemoyne Jean-Louis
-"Leonard, Robert"
+Larkin Goldsmith Mead
+Laurent Charles d' Houry
+Lawrence Kilburn (or Kilbrunn)
+Lee Krasner
+Leon Lamire
 Leonardo da Vinci
-"Lepsius, Richard"
-"Leutze, Emanuel"
-"Leyden, Lucas van"
-"Lichtenstein, Roy"
-"Liger, C."
-"Lilley, Robert"
-"Lippi, Filippino"
-"Lippi, Fra Filippo"
-"Lissitzky, El"
-"Lochner, Kunz"
-"Lodigiani, Luigi"
-"Lomazzo, Giovanni Paolo"
-"Lonberg-Holm, Knud"
+Leonora Carrington
+Lewis Hine
+Lisette Model
+Lockwood de Forest
+Lodewijck Grouwels
 London Society of Cabinet Makers
-"Longfellow, Henry Wadsworth"
-"Lorenzetti, Pietro"
+Lorenz Hauslaib
+Lorenzo Lotto
 Lorenzo Monaco (Piero di Giovanni)
-"Lotto, Lorenzo"
-"Louis, Morris"
+Louis Comfort Tiffany
+Louis Desplaces
+Louis Fort
+Louis Haghe
+Louis Tessier
+Louis Vuitton Co.
+Louis-Rémy Robert
+Louise Bourgeois
 Louiseboulanger
-"Lucas, David"
+Lucas Cranach the Elder
+Lucas van Leyden
+Lucian Freud
+Lucien Lévy-Dhurmer
+Ludovico Ariosto
+Ludwig Abels
+Ludwig Borchardt
+Ludwig Mies van der Rohe
+Luigi Chizzola
+Luigi Groto
+Luigi Lodigiani
+Luigi Palma di Cesnola
+Luigi Perego Salvioni
 Lycurgus Painter
 Lydos
+Lygia Pape
 Lysippides Painter
-"Léger, Fernand"
-"Lévy-Dhurmer, Lucien"
-"López, Francisco"
-MEMPHIS MILANO
-"MacMonnies, Frederick William"
-"MacNeil, Hermon Atkins"
-"Mackintosh, Charles Rennie"
+Léon Bakst
+Léon Gaucherel
+Léonard Limosin
+Léopold Bernard
+M. (Antoine) Bret
+M. (Guillaume de) Lavaur
+M. Knoedler & Co.
+Madame Grès (Alix Barton)
+Madeleine Vionnet
+Maestro Giorgio Andreoli
 Maestro delle Storie del Pane
-Mahmud Muzahib
-"Maiano, Giuliano da"
+Mahmud Muzahhib
 Mainbocher
 Maison Léoty
-"Malato, Enrico"
-Malory Thomas Sir
-Malthus Francis
+Mamadou Koyate (bridge by Djimo Koyate)
+Mamert Patisson
 Man Ray
-"Manet, Édouard"
-Mannello Angelo
 Manohar
-"Mantegna, Andrea"
+Manuel Ramírez
 Manufacture Nationale des Gobelins
+Marc Jacobs
+Marcantonio Raimondi
+Marcel Broodthaers
+Marcel Duchamp
 Marcilly
-"Marin, John"
+Marianne Brandt
+Mariano Fortuny
+Marie Geneviève Charlotte Darlus Thiroux d'Arconville
+Marie-Charles-Isidore Choiselat
+Marin Le Bourgeois
 Marius Michel et fils
-"Marmitta, Francesco"
-"Marquet, Albert"
-"Martel, Charles"
-Martin Christian Frederick
-"Martin, Docteur (Louis)"
-Martinellie Domenico
-"Martinez, Juan"
-"Martini, Simone"
-"Martínez, Francisco"
-Martínez Montañés Juan
-Master IC
+Mark Rothko
+Marquise de Montespan
+Marsden Hartley
+Martin Carlin
+Martin Johnson Heade
+Martin Schongauer
+Martin-Guillaume Biennais
+Mary Cassatt
+Master Heinrich of Constance
+Master IC (probably Jean Court)
 Master Potter A
 Master of Saint Francis
 Master of the Codex of Saint George
 Master of the Martyrdom of St. Sebastian
-"Matisse, Henri"
-"Matta, Roberto"
-"Matta-Clark, Gordon"
+Mathew B. Brady
+Matteo Sellas
+Matthew Digby Wyatt
+Matthew Pratt
+Matthias Walbaum
+"Matthys van de Merwede, Lord of Clootwyck"
 Maulana Azhar
-Mayhew John
-"Mazzinelli, Alessandro"
-McCardell Claire
-"McIntire, Samuel"
-McQueen Alexander
-"Mead, Larkin Goldsmith"
-"Meares, Richard"
+Maurice Brazil Prendergast
+Maurice Jacques
+Max Beckmann
+Max Ernst
+Max Weber
 Medici Porcelain Factory
 Meissen Manufactory
-Mekeren Jan van
-"Memling, Hans"
-"Merwede, Matthuys van de, Lord of Clootwyck"
-"Messerschmidt, Franz Xaver"
-Metropolitan Museum of Art
-"Metzker, Ray K."
-"Metzner, Ralph"
-"Michaux, Henri"
+Memphis Milano
+"Metalwork by Goto Teijo, 9th generation Goto master, Japan"
+Michael Ostendorfer
+Michal Rovner
+Michel Eugène Chevreul
+Michel Lambert
+Michel Redlin
 Michelangelo Buonarroti
-"Mies van der Rohe, Ludwig"
-"Mignard, Pierre"
-"Miller, Herman Inc."
-"Miller, Sally"
-"Milton, John"
+Michele Todini
+Michiel Sweerts
+Miguel Adrover
+Milton Avery
 Min Qiji
 Ministère de l'intérieur
 Mir 'Ali Haravi
-"Miró, Joan"
 Miskin
-"Model, Lisette"
-"Modigliani, Amedeo"
-"Molière, Jean-Baptiste Poquelin"
-"Molyneux, Edward"
-"Monet, Claude"
-"Monnet, Jean"
-"Montecuccoli, Raimondo, Prince"
-Montespan Marquise de
-"Moreau, Jean Michel, the Younger"
-"Morgan, J. Pierpont"
-"Morice, Charles"
-Morisset James
+Mme. Jeanne Paquin
 Morris & Company
+Morris Louis
 "Morris, Marshall, Faulkner & Co."
-"Morris, William"
-"Morse, Samuel F. B."
-Mosca Simone
-"Motherwell, Robert"
-"Mouchon, Pierre"
-"Moulin, Félix-Jacques-Antoine"
-"Mount, William Sidney"
-"Moura Portugal, Bento de"
-"Moynet, Simon"
-"Mozart, Anton"
-Muhammad Chand
 Muhammad Husain Kashmiri
 Muhammad ibn Aibak ibn 'Abdallah
 Muhammad ibn Badr al-Din Jajarmi
-"Muneakira, Myōchin"
-"Munesuke, Myōchin"
-"Muniz, Vik"
-"Munro, Rebekah S."
-"Murer, Christoph"
-"Murillo, Bartolomé Estebán"
-"Murray, Elizabeth"
+Murari Adhikari
 Museu de Arte Moderna
 Muslim Ibn al-Dahhan
 Mustafa b. Yusuf al-Darir al-Erzerumi
-"Myers, Myer"
-Mynardo Giovanni
-"Müller, Karl L. H."
+Mustafa ibn Vali
+Myer Myers
+Myōchin Muneakira
+Myōchin Munesuke
 Nadar
-"Naeplaesnigg, Andreas"
-"Nannini, Remigio"
-"Naville, Édouard F."
 Nearchos
-"Negroli, Filippo"
-"Neilson, Jacques"
-New Bremen Glass Manufactory 
+Nettie Rosenstein
+New Bremen Glass Manufactory
+Niccolò Eugenico
 Niccolò di Buonaccorso
+Niclaus Gerhaert von Leyden
 Nicola da Urbino
-"Nie, Chongyi"
-"Nimmo, J. C. and Bain"
+Nicolas Boileau Despréaux
+Nicolas Noël Boutet
+Nicolas Poussin
+Nicolás Enríquez
+Nikolaus von Hagenau
 Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
-"Noguchi, Isamu"
-Norman Barak
-"Noyse von Campenhouten, Johann Engelbert"
-Nunns Robert
+Norma Kamali
 Nymphenburg Porcelain Manufactory
-"Nègre, Charles"
-"O'Keeffe, Georgia"
-"O'Sullivan, Timothy H."
-"Oberlender, Johann Wilhelm"
-"Oeben, Jean-François"
-"Ohr, George E."
-"Oiticica, Hélio"
-"Oldenburg, Claes"
+Octave Uzanne
+Ogata Kōrin
+Ogden Nicholas Rood
+Olfert Dapper
 Olowe of Ise
-"Ongania, Ferdinando"
-"Onofri, Basilio"
-Oppenordt Alexandre-Jean
-"Orley, Bernard van"
+Onésipe Aguado de las Marismas
 Osservanza Master
-"Ostade, Adriaen van"
-"Ostendorfer, Michael"
+Ottaviano Diodati
+Otto Dix
+Otto Prutscher
+Otto Steinert
 Ovid
+Owen Jones
 PBM
-PUCELLE JEAN
-"Pabst, Daniel"
-"Pacetti, Giovanni Battista"
+Pablo Picasso
 "Pacetti, Vincenzo"
 Padeloup
 Painter of the Woolly Satyrs
-"Pajou, Augustin"
-"Palissy, Bernard"
-"Palladio, Andrea"
-"Palmer, Erastus Dow"
-"Panini, Giovanni Paolo"
-"Pannemaker, Pieter de"
-Pantin Simon I
-"Pape, Lygia"
-Paquin House of
-Paquin Jeanne
-"Passeri, Giuseppe"
-"Patinir, Joachim"
-"Patisson, Mamert"
-"Patou, House of"
-"Peale, Charles Willson"
-"Peale, James"
-"Peale, Raphaelle"
-"Peale, Rembrandt"
-"Peck, Peter"
-"Pellerin, Baptiste"
-"Penn, Irving"
+Paolo Veronese (Paolo Caliari)
+Patrick Faigenbaum
+Patty Coggeshall
+Paul Avril
+Paul Cézanne
+Paul Gauguin
+Paul Klee
+Paul Poiret
+Paul Revere Jr.
+Paul Signac
+Paul Strand
+Paul T. Frankl
+Peeter van der Borcht
 Penthesilea Painter
-"Percier, Charles"
-Pere Alexandre & Fils
 Perino del Vaga (Pietro Buonaccorsi)
-Permoser Balthasar
-"Pernon, Camille"
 Persephone Painter
 Persius
-"Peruzzi, Baldassare Tommaso"
-Pesquera Diego de
+Peter Blume
+Peter Langlois
+Peter Lekeux
+Peter Paul Rubens
+Peter Peck
 Petronius Arbiter
-Pfau David II
-Pfau Hans Heinrich III
-"Phyfe, Duncan"
-"Picasso, Pablo"
+Petrus Apianus
+Petrus Christus
+Philip Guston
+Philip Webb
 Piero di Cosimo (Piero di Lorenzo di Piero d'Antonio)
+Pierre Bonnard
+Pierre Didot l'ainé
+Pierre Gilles
+Pierre Le Bourgeois
+Pierre Mignard 
+Pierre Mouchon
 Pierre Paupie
+Pierre Pithou
+Pierre Rémond
 Pierre de Goesin
-"Pigna, Giovanni Battista"
-"Pippin, Horace"
-"Piranesi, Giovanni Battista"
-"Pisano, Giovanni"
-"Pithou, Pierre"
+Pieter Bruegel the Elder
+Pieter de Hooch
+Pieter de Pannemaker
+Pietro Bernini
+Pietro Lorenzetti
 "Plandome Press, Inc."
-"Plon E., Nourrit et Cie."
 Plutarch
-"Poiret, Paul"
-"Polke, Sigmar"
-"Pollaiuolo, Antonio"
-"Pollock, Jackson"
 Polykleitos
 Polyteleia Painter
-"Pons, Joseph"
-"Porro, Girolamo"
-"Porta, Guglielmo della"
-"Porthaux, Dominique Antony"
 Pottier and Stymus Manufacturing Company
-"Poussin, Nicolas"
-"Powers, Hiram"
-"Pratt, Matthew"
-"Prendergast, Maurice Brazil"
-"Price, William Lightfoot"
 Prince Lu
-"Prince, Richard"
-"Proctor, Alexander Phimister"
-"Prutscher, Otto"
-QIAN XUAN
-QU DING
+Prince Raimondo Montecuccoli
+Prince Wenzel von Kaunitz-Rietberg
 Qasim ibn 'Ali
-"Raimondi, Marcantonio"
-"Ramírez, Manuel"
+Qian Xuan
+Qu Ding
+Rai Kunitoshi
+Ralph Earl
+Ralph Metzner
 Raphael (Raffaello Sanzio or Santi)
-"Ratel, Stanislas"
-"Rauschenberg, Robert"
-"Ray, Charles"
-Reboux Caroline
-Redlin Michel
-"Reiff, Jacob"
+Raphaelle Peale
+Ray K. Metzker
+Rebekah S. Munro
+Red Grooms
+Reinhold Vasters
 Rembrandt (Rembrandt van Rijn)
-"Remington, Frederic"
-"Renoir, Auguste"
-"Revere, Paul, Jr."
-"Reynolds, Joshua, Sir"
-"Ribera, Jusepe de (called Lo Spagnoletto)"
-"Richards, William Trost"
-"Richters, Hendrik"
-"Ridolfi, Carlo"
-Riemenschneider Tilman
-"Riesener, Jean Henri"
-"Ringgold, Faith"
+Rembrandt Peale
+Remigio Nannini
+Remy Belleau
+René-Jules Lalique
+Rev. George Croly
+Richard Alpert
+Richard Holden
+Richard Lepsius
+Richard Meares
+Richard Prince
 Riza-yi `Abbasi
-"Robbia, Andrea della"
-"Robert, Louis-Rémy"
-"Roberts, David"
-"Roché, H. P."
-"Rodin, Auguste"
-"Rodríguez Juárez, Juan"
-"Roentgen, David"
+Robert  Adamson
+Robert Adam
+Robert Campin
+Robert Estienne
+Robert Fisher
+Robert Joly
+Robert Leonard
+Robert Lilley
+Robert Motherwell
+Robert Nunns
+Robert Rauschenberg
+Robert Smithson
+Roberto Matta
+Roger Fenton
+"Roger Vandercruse, called Lacroix"
 Rogier van der Weyden
-"Rohde, Gilbert"
-"Rood, Ogden Nicholas"
-Rose Joseph
-"Rosenquist, James"
-Rosenstein Nettie
-Rossberg Herman
-"Rossellino, Antonio"
-"Rossetti, Dante Gabriel"
-"Rossi, Giovanni Giacomo De"
-"Rota, Giovanni"
-"Roth, Heinrich"
-"Rothko, Mark"
-"Rousseau, Henri (le Douanier)"
-"Roux, Alexander"
-"Rovner, Michal"
+Romare Bearden
+Romeyn de Hooghe
+Rosa Bonheur
+Roy Lichtenstein
 Royal Asiatic Society
 Royal Workshops at Greenwich
-"Rubens, Peter Paul"
-"Ruff, Thomas"
-"Ruhlmann, Émile-Jacques"
-"Ruisdael, Jacob van"
-"Ruscelli, Girolamo (Alessio Piemontese)"
-"Rush, William"
+Rudi Gernreich
+Rudolf Baranik
+Rufus Hathaway
 Rébè
-"Régamey, Félix"
-"Rémond, Pierre"
-"Saarinen, Eliel"
-Saint Laurent Yves
-"Saint Laurent Yves, Paris"
-"Saint-Gaudens, Augustus"
+S. & T. Gilbert
 Salerno Editrice
-Salvioni
-"Sander, August"
-Sant'Angelo Giorgio
-"Sargent, John Singer"
-"Sarto, Andrea del (Andrea d'Agnolo)"
-"Sax, Charles Joseph"
-"Scherer, Georg Henrich"
-Schiaparelli Elsa
-"Schiele, Egon"
-"Schmidt, Jacob"
-Scholte
-"Schongauer, Martin"
+Sally Miller
+Salvador Dalí
+Salvatore Ferragamo
+Samuel Bidermann
+Samuel Colt
+Samuel F. B. Morse
+Samuel Jackson
+Samuel McIntire
+Samuel Putnam Avery Sr.
+Sanford Robinson Gifford
+Saotome Iyetada
+Sarah Furman Warner Williams
 Schramberg Majolica Factory
-"Schrenck von Nozing, Jacob"
-"Schroll, A."
-"Schuech, Israel"
-"Searle, William"
-"Seeley, George H."
-"Sellas, Matteo"
-"Serlio, Sebastiano"
+Sebastiano Serlio
+Sefferin Alken
 Sesson Shūkei
-"Seurat, Georges"
+Seymour Joseph Guy
 Shah Quli
-Shaykh Zada
-"Sheeler, Charles"
-"Sheraton, Thomas"
-"Sherman, Cindy"
-"Signac, Paul"
-"Siloe, Gil de"
-"Silve, David"
+Shaikh Zada
+Shifu Wang
+Sidney Gardiner
+Sigmar Polke
 Simca Print Artists Inc.
 Simier
+Simon Bening
+Simon Moynet
+Simon Pantin I
+Simone Martini
+Simone Mosca
 Sioux
-"Smibert, John"
-"Smith, David"
-"Smith, John Rubens"
-"Smithson, Robert"
-"Soligny, Eugene J."
-"Sottsass, Ettore"
-"Soudbinine, Séraphin"
-"Soufflot, Jacques Germain"
+Sir Edward Burne-Jones
+Sir Joshua Reynolds
+Sir Richard Westmacott
+Sir Thomas Lawrence
+Sir Thomas Malory
 Southworth and Hawes
-"Southworth, Albert Sands"
-"Sparre, Baron de"
 Spaulding and Company
-"Spranger, Bartholomeus"
-"Stazio, Abbondio"
-"Steen, Jan"
-"Steichen, Edward J."
-"Steinert, Otto"
-Stephens John Lloyd
-"Stiegel, Henry William"
-"Stieglitz, Alfred"
-"Still, Clyfford"
-"Stimmer, Tobias"
-"Story, William Wetmore"
-"Stradivari, Antonio"
-"Strahan, Edward"
-"Strand, Paul"
-"Struth, Thomas"
-"Stuart, Gilbert"
+Stanislas Ratel
+Stefano da Verona (Stefano di Giovanni)
+Steffan Cuntz
+Stephen Hannock
+Stuart Davis
 Studio 65
-"Sugimoto, Hiroshi"
 Sukemitsu of Bizen
-"Sully, Thomas"
 Sulpicia
 Sultan Muhammad
 Sultan Muhammad Nur
 Sultan Murad III
 Suzi
-"Sweerts, Michiel"
 Sèvres Manufactory
-"Tachaux, Daniel"
-"Talbot, William Henry Fox"
-"Tanner, Henry Ossawa"
-"Targee, John"
-Tarnowski Jan and Valeria Count and Countess
+Séraphin Soudbinine
+T. Lux Feininger
+Tadamasa Hayashi
+Taddeo Zuccaro
+Takuo Itoh
 Tarporley Painter
-"Taylor, I. & J."
-Tecchler David
-Teijo Goto
-"Tekelü, Ahmed"
-"Tencalla, Carpoforo Mazzetti"
-Teng Yeohlee
-"Tessier, Louis"
+"The Herman Miller Furniture Company, Zeeland, MI"
 The Limbourg Brothers
-Thibault Girard
-"Thiout, Antoine"
-"Thiroux d'Arconville, Marie Geneviève Charlotte Darlus"
-"Thomas, Auguste H."
-"Thomassin, Henri Simon"
-Tielke Joachim
-"Tiepolo, Giovanni Battista"
-"Tiepolo, Giovanni Domenico"
+The Metropolitan Museum of Art
+Theodore Henry Adolphus Fielding
+Theophilo Folengo
+Thomas Anshutz
+Thomas Appleton
+Thomas Bensley
+Thomas Blockley
+Thomas Chippendale
+Thomas Coenraet Boekhout
+Thomas Cole
+Thomas Crawford
+Thomas Dennis
+Thomas Eakins
+Thomas Fletcher
+Thomas Gainsborough
+Thomas Hart Benton
+Thomas Ruff
+Thomas Sheraton
+Thomas Struth
+Thomas Sully
+Thomas Toft
+Thomas Whately
+Thomas Wilmer Dewing
+Théodore Gericault
 Tiffany & Co.
 Tiffany Glass and Decorating Company
-"Tiffany, Louis Comfort"
+Tilman Riemenschneider
+Timothy H. O'Sullivan
+Timothy Leary
 "Tindale, Thomas & Harriet R."
-"Tinguely, Jean"
-"Tissot, Jean-Claude"
 Titian (Tiziano Vecellio)
-"Todini, Michele"
-Toft Thomas
+Tobias Stimmer
+Tom Ford
 Tong zhi tang
-"Toulouse-Lautrec, Henri de"
-"Tournachon, Adrien"
-Townley
-"Townsend, John"
-"Treviso, Girolamo da"
-"Trumbull, John"
-"Turner, Joseph Mallord William"
+Townley Frocks
+Traiano Boccalini
+Ugo da Carpi
 Ugolino da Siena (Ugolino di Nerio)
+Umberto Boccioni
 Umbo (Otto Umbehr)
-Ungaro Emanuel
 Unidentified Artist
 Unknown
-"Uzanne, Octave"
+Urs Graf
+V. Dijon
+Valentin Bousch
 Valentin de Boulogne
 Valentina
-"Vali, Mustafa ibn"
-"Vallotton, Félix"
-"Vallou-de-Villeneuve, Julien"
-Vandercruse Roger called Lacroix
-"Vanderlyn, John"
-Vasaro Giovanni Maria
-"Vasters, Reinhold"
+Vasily Kandinsky
+Veit Langenbucher
 Velázquez (Diego Rodríguez de Silva y Velázquez)
-"Vermeer, Johannes"
-"Verona, Stefano da"
-"Veronese, Paolo (Paolo Caliari)"
-Versace Gianni
-"Vignola, Jacopo [Giacomo] Barozzi da"
+Vicente Carducho
+Vik Muniz
 Viking Press
-"Vile, William"
-"Villon, Jacques"
 Vincennes Manufactory
-"Vionnet, Madeleine"
-Voboam Jean-Baptiste
-"Voiriot, Guillaume"
-"Voll, Georg"
-"Vollard, Ambroise"
+Vincent van Gogh
+Vincenzo Giuntini
+Vittore Carpaccio
+Vivienne Westwood
 Voltaire
-"Vonnoh, Bessie Potter"
-"Vuillard, Édouard"
-Vuillaume Jean Baptiste
-Vuitton Louis
-WILCOX SILVER
-Walbaum Matthias
-"Wall, Jeff"
+Vranke van der Stockt
+W. Brown and A. O'Neil
+Walker Evans
 Wang Hui
-"Wang, Fu"
-"Wang, Shifu"
-"Ward, John Quincy Adams"
-"Warhol, Andy"
-"Waring, J. B."
-"Washburn, Ives"
-Watanabe Junya
-"Watkins, Carleton E."
-"Watteau, Antoine"
-Webb Philip
-"Weber, Max"
-"Wedgwood and Sons, Josiah"
-"Wedgwood, Josiah"
 Weeks
-"Wesenbeke, Jacques de"
-"West, Benjamin"
-"Westmacott, Richard, Sir"
-"Westwood, J. O."
-"Westwood, Vivienne"
-"Whately, Thomas"
-"Whipple, John Adams"
-"Whistler, James McNeill"
-"White, Clarence H."
-"Whitehouse, James Horton"
-"Whittredge, Worthington"
+Wharton Esherick
 Wiener Werkstätte
-Wildsmith John
-"Wiles, Irving Ramsey"
-"Williamson, George Charles"
-"Wilton, Joseph"
-"Winogrand, Garry"
-"Winslow, Edward"
-"Wood, Grant"
-"Woodman, Francesca"
-Woolnough Charles W.
-Workshop of Biduinus
-"Worth, Charles Frederick"
-"Worth, House of"
-"Wright, Frank Lloyd"
+Wilhelm Froehner
+Willem de Kooning
+William Addison Dwiggins
+William Baziotes
+William Henry Fox Talbot
+William Ignatius Blemly
+William Ince
+William James Glackens
+William Klein
+William Lightfoot Price
+William Loring Andrews
+William Merritt Chase
+William Morris
+William Rush
+William Searle
+William Sidney Mount
+William Trost Richards
+William Vile
+William Wetmore Story
+Winslow Homer
+Worthington Whittredge
 Wu Bin
-"Wyatt, Matthew Digby Sir"
 Yale University Press
-"Yamamoto, Yohji"
 Yasumitsu
-"Zeisel, Eva"
-"Zick, Januarius"
+Yeohlee Teng
+Yohji Yamamoto
+Yves Saint Laurent
+"Yves Saint Laurent, Paris"
 Zlan of Belewale
-"Zuccaro, Taddeo"
-"Zurbarán, Francisco de"
-"de Forest, Lockwood"
-"de Frías, Joseph"
-de Liège Jean
-"de Meyer, Adolf"
-de Perefixe Hardouin
-"de Querlon, Anne Gabriel Meusnier"
-de Touyl Jean
-de Werve Claus
+`Abd al-Rahman al-Sufi
+baron Dominique Vivant Denon
+de Bernieres
 del Tasso
-"van der Stockt, Vranke"
-"von Hagenau, Nikolaus"
-"von Winterthur, Heinrich Heid"
+probably A. Boslwert
+probably the Elseviers of Leyden
+workshop of Giovanni Maria Vasaro
+Èmile Grittel
+Édouard Baldus
+Édouard F. Naville
+Édouard Manet
+Édouard Vuillard
+Émile-Jacques Ruhlmann
 Érard
+Étienne Delaune
 ‘Umar ibn Yusuf ibn ‘Umar ibn ‘Ali ibn Rasul al-Muzaffari

--- a/scripts/output/met_artwork/met_artwork-artwork_artists-split.csv
+++ b/scripts/output/met_artwork/met_artwork-artwork_artists-split.csv
@@ -1,0 +1,1475 @@
+Object Number,variable,artist
+02.7.1,0,"Ingham, Charles Cromwell"
+04.29.2,0,"Cole, Thomas"
+04.3.36,0,"von Winterthur, Heinrich Heid"
+06.1051.2,0,"Altdorfer, Albrecht"
+06.1335.1a–d,0,"Tencalla, Carpoforo Mazzetti"
+06.1335.1a–d,1,"Stazio, Abbondio"
+06.968.2,0,"Stimmer, Tobias"
+06.968.2,1,"Murer, Christoph"
+06.968.2,2,Pfau David II
+06.968.2,3,Pfau Hans Heinrich III
+"07.286.36a, b",0,Penthesilea Painter
+07.286.84,0,Painter of the Woolly Satyrs
+08.162.1,0,"Rossetti, Dante Gabriel"
+08.162.1,1,"Dunn, Henry Treffry"
+08.183.1,0,"Bellini, Giovanni"
+10.125.685,0,"Dennis, Thomas"
+10.125.685,1,"Searle, William"
+10.125.83,0,"Townsend, John"
+10.189,0,"Veronese, Paolo (Paolo Caliari)"
+10.228.1,0,"Homer, Winslow"
+10.64.5,0,"Homer, Winslow"
+100.1 B59,0,"Blanc, Charles"
+100.1 B59,1,"Humbert, de Superville David-Pierre Giottino"
+100.1 B591,0,"Gaucherel, Léon"
+100.1 B591,1,"Blanc, Charles"
+100.51 B61 no.2,0,Man Ray
+100.51 B61 no.2,1,"Duchamp, Marcel"
+100.51 B61 no.2,2,"Roché, H. P."
+106.1 V28 F,0,Barrie
+106.1 V28 F,1,"Strahan, Edward"
+107.1 K75 1920 no.8,0,"Bakst, Léon"
+107.1 K75 1920 no.8,1,"Knoedler, M., & Co."
+107.15 R474 no.7,0,Museu de Arte Moderna
+109A L83,0,"Lomazzo, Giovanni Paolo"
+11.116.4,0,"Inness, George"
+11.118,0,"Carpaccio, Vittore"
+11.126.1,0,Giotto di Bondone
+11.156,0,"Durand, Asher Brown"
+11.173.1,0,"Rodin, Auguste"
+110.5B75 C44,0,"Chizzola, Luigi"
+12.11.1,0,"Rodin, Auguste"
+12.3.1,0,Master Potter A
+120 Se6,0,"Serlio, Sebastiano"
+120.32P17 P17,0,"Palladio, Andrea"
+123.1 F412,0,"Washburn, Ives"
+123.1 F412,1,"Ferriss, Hugh"
+125.97 D932,0,"Dürer, Albrecht"
+126.5V55 B292 Q v.3,0,"Boito, Camillo"
+126.5V55 B292 Q v.3,1,"Ongania, Ferdinando"
+126.6 R61,0,"Colin et Cie., Éditeurs"
+126.6 R61,1,"Rodin, Auguste"
+126.6 R61,2,"Morice, Charles"
+13.160.10,0,Al-Sufi `Abd al-Rahman
+13.2,0,"Whistler, James McNeill"
+13.228.13.6,0,Maulana Azhar
+13.228.13.6,1,Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
+13.228.13.6,2,Unknown
+13.228.26,0,Miskin
+13.228.26,1,Amir Khusrau Dihlavi
+13.228.28,0,Miskin
+13.228.28,1,Amir Khusrau Dihlavi
+13.228.29,0,Basawan
+13.228.29,1,Muhammad Husain Kashmiri
+13.228.29,2,Amir Khusrau Dihlavi
+13.228.33,0,Manohar
+13.228.33,1,Muhammad Husain Kashmiri
+13.228.33,2,Amir Khusrau Dihlavi
+13.228.7.5,0,Sultan Muhammad Nur
+13.228.7.5,1,Mahmud Muzahib
+13.228.7.5,2,Shaykh Zada
+13.228.7.5,3,Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
+130.8 C23,0,"Carradori, Francesco"
+131.1M58 C75,0,"Condivi, Ascanio"
+139.3 N48 F,0,"Hayashi, Tadamasa"
+139.3 N48 F,1,De Vinne Press
+139.3 N48 F,2,"Bishop, Heber R."
+139.3 N48 F,3,Kunz George Frederick
+139.3 N48 F,4,Bushell Stephen Wootton Dr.
+139.3 N48 F,5,"Lilley, Robert"
+14.100.172,0,"Iyetada, Saotome"
+14.100.172,1,"Munesuke, Myōchin"
+14.126.1,0,"Sully, Thomas"
+14.130.12,0,Euphiletos Painter
+14.130.14,0,Hirschfeld Workshop
+14.25.1425,0,"Gemlich, Ambrosius"
+14.25.1425,1,"Peck, Peter"
+14.25.1623,0,"Schmidt, Jacob"
+14.26,0,"Coggeshall, Patty"
+14.40.602,0,"Hals, Frans"
+14.40.605,0,"Hals, Frans"
+14.40.618,0,Rembrandt (Rembrandt van Rijn)
+14.40.619,0,"Dyck, Anthony van"
+14.40.623,0,"Ruisdael, Jacob van"
+14.40.626–27,0,"Memling, Hans"
+14.40.633,0,"Dürer, Albrecht"
+14.40.642,0,Botticelli (Alessandro di Mariano Filipepi)
+14.40.675,0,"Rossellino, Antonio"
+14.40.687,0,Clodion (Claude Michel)
+14.40.689,0,Giambologna
+14.74.17,0,American Flint Glass Manufactory 
+14.74.17,1,"Stiegel, Henry William"
+14.76.6,0,Unidentified Artist
+143.6 S92,0,"Froehner, Wilhelm"
+143.7W41 W413,0,"Wedgwood, Josiah"
+146.8  M821 Q,0,"Morgan, J. Pierpont"
+146.8  M821 Q,1,"Williamson, George Charles"
+146.9 T34,0,"Thiout, Antoine"
+15.113.1–.5; 29.158.885,0,"Holden, Richard"
+15.113.1–.5; 29.158.885,1,"Tachaux, Daniel"
+15.142.2,0,"Sargent, John Singer"
+15.30.59,0,"Durand, Asher Brown"
+15.30.61,0,"Kensett, John Frederick"
+15.30.62,0,"Gifford, Sanford Robinson"
+15.30.67,0,"Church, Frederic Edwin"
+15.75,0,"French, Daniel Chester"
+152.7 T36 Q,0,"Thomas, Auguste H."
+153 Ar7 F,0,Appleton & Co.
+159.4 N486,0,"Plandome Press, Inc."
+159.4 N486,1,"Silve, David"
+159.4 N486,2,"Dwiggins, William Addison"
+159.4 N486,3,Metropolitan Museum of Art
+16.2.2,0,"Cassatt, Mary"
+16.30ab,0,Raphael (Raffaello Sanzio or Santi)
+16.53,0,"Sargent, John Singer"
+16.68.2,0,"Blackburn, Joseph"
+161 H41,0,"Taylor, I. & J."
+161 H41,1,"Hepplewhite, A. & Co."
+161 L841,0,"Brown, W. and O'Neil A."
+161 L841,1,London Society of Cabinet Makers
+161.1 C44 Q,0,"Chippendale, Thomas"
+17.104,0,"Saint-Gaudens, Augustus"
+17.142.1,0,Leonardo da Vinci
+17.172,0,"Eakins, Thomas"
+17.190.1720,0,"Negroli, Filippo"
+17.190.2045,0,Medici Porcelain Factory
+17.190.636,0,"Emmoser, Gerhard"
+17.190.724,0,Heinrich of Constance Master
+17.190.823,0,Walbaum Matthias
+17.190.823,1,"Mozart, Anton"
+"17.230.14a, b",0,Exekias
+17.3.159,0,"Whistler, James McNeill"
+17.3.90,0,"Whistler, James McNeill"
+17.40.2a–r,0,Bousch Valentin
+17.50.17-36,0,"Castiglione, Giovanni Benedetto (Il Grechetto)"
+17.50.17-36,1,"Merwede, Matthuys van de, Lord of Clootwyck"
+17.50.17-36,2,"Rossi, Giovanni Giacomo De"
+17.81.4,0,Bihzad
+17.81.4,1,Hafiz
+"17.87.3a, b",0,"Liger, C."
+17.90.1,0,"Saint-Gaudens, Augustus"
+17.97.5,0,"Whistler, James McNeill"
+170.1 AL1 Quarto,0,"Albers, Josef"
+170.1 AL1 Quarto,1,Yale University Press
+170.1 C424,0,"Chevreul, Michel Eugène"
+170.1 C424,1,"Martel, Charles"
+170.1 R674,0,"Rood, Ogden Nicholas"
+170.9 F46,0,"Fielding, Theodore Henry Adolphus"
+171.1 C17,0,"Carducho, Vincente"
+171.1 C17,1,"Martínez, Francisco"
+171.1 C17,2,"López, Francisco"
+171.1 C17,3,"Fernández, Francisco"
+175T49 R43,0,"Ridolfi, Carlo"
+18.70.28,0,"Pisano, Giovanni"
+19.115.2,0,"Muneakira, Myōchin"
+19.126,0,"MacNeil, Hermon Atkins"
+"19.131.1a–r, t–w, .2a–c; 27.183.16",0,Royal Workshops at Greenwich
+"19.131.1a–r, t–w, .2a–c; 27.183.16",1,"Holbein, Hans, the Younger"
+19.164,0,"Bruegel, Pieter, the Elder"
+19.51.7,0,"Degas, Edgar"
+19.51.7,1,"Manet, Édouard"
+19.68.1,0,Muhammad ibn Badr al-Din Jajarmi
+19.73.1,0,"Dürer, Albrecht"
+19.74.1,0,"Raimondi, Marcantonio"
+19.74.1,1,Raphael (Raffaello Sanzio or Santi)
+19.77.2,0,"Ingres, Jean Auguste Dominique"
+192H221  B61,0,Blemly William Ignatius
+1950-04-01 00:00:00,0,"Penn, Irving"
+1970.137.1,0,Riemenschneider Tilman
+1970.179.1a–q,0,"Boutet, Nicholas-Noël"
+1970.230.4,0,Vincennes Manufactory
+1970.230.4,1,"Duplessis, Jean-Claude"
+1970.301.2,0,Sultan Muhammad
+1970.301.2,1,Abu'l Qasim Firdausi
+1970.301.3,0,Sultan Muhammad
+1970.301.3,1,Abu'l Qasim Firdausi
+1970.301.51,0,Qasim ibn 'Ali
+1970.301.51,1,Abu'l Qasim Firdausi
+1970.35.1,0,Pottier and Stymus Manufacturing Company
+1970.727.1,0,"Hine, Lewis"
+1970.77,0,"Schuech, Israel"
+1970.77,1,"Martinez, Juan"
+1970.89.1a–c,0,Ungaro Emanuel
+1971.155,0,"Carracci, Annibale"
+1971.158.1,0,Mosca Simone
+1971.219,0,"Roux, Alexander"
+1971.63.1,0,"Panini, Giovanni Paolo"
+1971.79.4,0,"Givenchy, Hubert de"
+1971.79.4,1,Givenchy House of
+1971.86,0,Velázquez (Diego Rodríguez de Silva y Velázquez)
+1972.111.1a-c,0,Mannello Angelo
+1972.118.210,0,"Delacroix, Eugène"
+1972.127,0,"Smith, David"
+1972.223,0,"Le Bourgeois, Pierre"
+1972.223,1,"Le Bourgeois, Marin"
+1972.263.6,0,"Davis, Joseph H."
+1972.47,0,Herter Brothers
+1972.60.1,0,"Wright, Frank Lloyd"
+"1973.104.2a, b",0,"Grès, Madame"
+1973.120.1,0,QU DING
+1973.120.6,0,QIAN XUAN
+1973.257,0,"Ward, John Quincy Adams"
+1973.282.2,0,Ferragamo Salvatore
+1973.315.1,0,Joubert Gilles
+1973.634,0,Canaletto (Giovanni Antonio Canal)
+"1973.6a, b",0,Louiseboulanger
+1974.136.3,0,"Courrèges, André"
+1974.185.3a–c,0,Harris H.
+1974.185.3a–c,1,Scholte
+"1974.214.26a, b",0,Gorham Manufacturing Company
+"1974.214.26a, b",1,Spaulding and Company
+1974.356.120a,0,"Bauer, Johann Michael"
+1974.356.524,0,"Bustelli, Franz Anton"
+1974.356.524,1,Nymphenburg Porcelain Manufactory
+1975.1.1015,0,Vasaro Giovanni Maria
+1975.1.1019,0,Nicola da Urbino
+1975.1.103,0,"Baronzio, Giovanni"
+1975.1.104,0,Master of Saint Francis
+1975.1.110,0,"Christus, Petrus"
+1975.1.1103,0,"Andreoli, Giorgio Maestro"
+1975.1.113,0,"Memling, Hans"
+1975.1.119,0,"David, Gerard"
+1975.1.1194,0,Italian
+1975.1.1194,1,French
+1975.1.12,0,"Martini, Simone"
+1975.1.120,0,"David, Gerard"
+1975.1.1232,0,Master IC
+1975.1.1232,1,"Cour, Jean"
+1975.1.1244,0,"Goullons, Jacques"
+1975.1.130,0,"Hey, Jean (called Master of Moulins)"
+1975.1.138,0,"Holbein, Hans, the Younger"
+1975.1.140,0,Rembrandt (Rembrandt van Rijn)
+1975.1.141,0,"Borch, Gerard ter, the Younger"
+1975.1.142,0,"Borch, Gerard ter, the Younger"
+1975.1.144,0,"Hooch, Pieter de"
+1975.1.145,0,"Greco, El (Domenikos Theotokopoulos)"
+1975.1.146,0,"Greco, El (Domenikos Theotokopoulos)"
+1975.1.148,0,Goya (Francisco de Goya y Lucientes)
+1975.1.155,0,Balthus (Balthasar Klossowski)
+1975.1.1558,0,"Vasters, Reinhold"
+1975.1.1558,1,Italian
+1975.1.156,0,"Bonnard, Pierre"
+1975.1.159,0,"Braque, Georges"
+1975.1.16,0,Bartolo di Fredi
+1975.1.160,0,"Cézanne, Paul"
+1975.1.162,0,"Corot, Camille"
+1975.1.1638,0,del Tasso
+1975.1.168,0,"Derain, André"
+1975.1.186,0,"Ingres, Jean Auguste Dominique"
+1975.1.1915,0,"Orley, Bernard van"
+1975.1.1915,1,"Pannemaker, Pieter de"
+1975.1.192,0,"Marquet, Albert"
+1975.1.194,0,"Matisse, Henri"
+1975.1.196,0,"Monet, Claude"
+1975.1.199,0,"Renoir, Auguste"
+1975.1.201,0,"Renoir, Auguste"
+1975.1.2026,0,"Carlin, Martin"
+1975.1.2026,1,Sèvres Manufactory
+1975.1.2026,2,French
+1975.1.209,0,"Signac, Paul"
+1975.1.21,0,Niccolò di Buonaccorso
+1975.1.2101,0,"Italian, Siena"
+1975.1.225,0,"Vuillard, Édouard"
+1975.1.231,0,"Gogh, Vincent van"
+1975.1.2486,0,"David, Gerard"
+1975.1.2487,0,"Bening, Simon"
+1975.1.2490,0,"Fouquet, Jean"
+1975.1.2491,0,"Marmitta, Francesco"
+1975.1.27,0,Osservanza Master
+1975.1.270,0,"Bartolomeo, Fra (Bartolomeo di Paolo del Fattorino)"
+1975.1.297,0,Canaletto (Giovanni Antonio Canal)
+1975.1.31,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
+1975.1.335,0,Lorenzo Monaco (Piero di Giovanni)
+1975.1.342,0,"Guardi, Francesco"
+1975.1.369,0,Leonardo da Vinci
+1975.1.37,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
+1975.1.376,0,Francesco di Giorgio Martini
+1975.1.38,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
+1975.1.410,0,"Pollaiuolo, Antonio"
+1975.1.443,0,"Tiepolo, Giovanni Battista"
+1975.1.473,0,"Tiepolo, Giovanni Domenico"
+1975.1.514,0,"Tiepolo, Giovanni Domenico"
+1975.1.54,0,Benvenuto di Giovanni
+1975.1.553,0,"Zuccaro, Taddeo"
+1975.1.58,0,"Daddi, Bernardo"
+1975.1.592,0,"Cross, Henri-Edmond"
+1975.1.647,0,"Ingres, Jean Auguste Dominique"
+1975.1.66,0,Lorenzo Monaco (Piero di Giovanni)
+1975.1.661,0,Claude Lorrain (Claude Gellée)
+1975.1.669,0,"Matisse, Henri"
+1975.1.7,0,Ugolino da Siena (Ugolino di Nerio)
+1975.1.704,0,"Seurat, Georges"
+1975.1.710,0,"Signac, Paul"
+1975.1.731,0,"Toulouse-Lautrec, Henri de"
+1975.1.736,0,"Vallotton, Félix"
+1975.1.74,0,Botticelli (Alessandro di Mariano Filipepi)
+1975.1.753,0,"Villon, Jacques"
+1975.1.763,0,"Watteau, Antoine"
+1975.1.774,0,"Gogh, Vincent van"
+1975.1.792,0,Rembrandt (Rembrandt van Rijn)
+1975.1.794,0,Rembrandt (Rembrandt van Rijn)
+1975.1.799,0,Rembrandt (Rembrandt van Rijn)
+1975.1.843,0,"Rubens, Peter Paul"
+1975.1.848,0,"van der Stockt, Vranke"
+1975.1.85,0,Jacometto (Jacometto Veneziano)
+1975.1.855,0,"Baldung, Hans (called Hans Baldung Grien)"
+1975.1.859,0,"Dürer, Albrecht"
+1975.1.86,0,Jacometto (Jacometto Veneziano)
+1975.1.872,0,"Schongauer, Martin"
+1975.1.940,0,"Prendergast, Maurice Brazil"
+1975.1.95,0,Maestro delle Storie del Pane
+1975.1.96,0,Maestro delle Storie del Pane
+1975.15a–c,0,"Doucet, Jacques"
+1975.16,0,"Heade, Martin Johnson"
+1975.246.5a–c,0,James Charles
+1975.268.48a–d,0,Kano Sansetsu
+1975.27.1,0,"Edmonds, Francis William"
+1975.319.1,0,"Cassatt, Mary"
+1975.321,0,"Weber, Max"
+1975.59,0,Koyate Mamadou
+1976.124.7a–c,0,"Balenciaga, Cristobal"
+1976.124.7a–c,1,Balenciaga House of
+1976.155.110,0,"Carlin, Martin"
+1976.155.110,1,"Bouillat père, Edme François"
+1976.155.110,2,Sèvres Manufactory
+1976.324,0,"Barry, and Son Joseph B."
+1976.332,0,"Trumbull, John"
+"1976.368.5a, b",0,"Blass, Bill"
+"1976.368.5a, b",1,PBM
+"1976.368.5a, b",2,Bonwit Teller & Co.
+1976.414.3a-ggg,0,"Dupas, Jean"
+1976.414.3a-ggg,1,"Champigneulle, Jacques-Charles"
+1976.646,0,"Le Gray, Gustave"
+1976.652.3-4,0,"Edouart, Auguste"
+1976.92,0,"Bernini, Gian Lorenzo"
+1976.92,1,"Bernini, Pietro"
+1977.1,0,"David, Jacques Louis"
+1977.1.11,0,"Heiglen, Johann Erhard"
+1977.1.3,0,"Tiepolo, Giovanni Battista"
+1977.243,0,"Stuart, Gilbert"
+"1977.329.5a, b",0,Rébè
+"1977.329.5a, b",1,Saint Laurent Yves
+"1977.329.5a, b",2,"Dior, House of"
+1977.78,0,HAN GAN
+1978.163.2a–c,0,Kamali Norma
+1978.203,0,"Lane, Fitz Henry"
+1978.288.23a–f,0,Schiaparelli Elsa
+1978.288.23a–f,1,Bonwit Teller & Co.
+"1978.288.7a, b",0,Callot Soeurs
+1978.412.499,0,Zlan of Belewale
+1978.61.1-.6,0,"Bearden, Romare"
+1979.206.1047,0,Chakalte'
+1979.29,0,Buli Master
+1979.32,0,"Esherick, Wharton"
+"1979.380a, b",0,Martin Christian Frederick
+1979.394,0,"Ward, John Quincy Adams"
+1979.395,0,"Earl, Ralph"
+1979.396.1,0,"Vermeer, Johannes"
+"1979.435.10a, b",0,"Givenchy, Hubert de"
+"1979.435.10a, b",1,Givenchy House of
+1979.5a–d,0,Wang Hui
+1979.622,0,"Watkins, Carleton E."
+1980.1023.5,0,Brassaï
+"1980.111a,b",0,Grenser H.
+1980.351,0,"Mies van der Rohe, Ludwig"
+1980.42,0,"Lichtenstein, Roy"
+1980.92.1a–c,0,Drecoll
+1981.238,0,"Rubens, Peter Paul"
+1981.276,0,Guo Xi
+1981.278,0,Huizong Emperor
+1981.35,0,"O'Keeffe, Georgia"
+1981.380.2,0,Callot Soeurs
+1981.4.1a–o,0,GONG XIAN
+"1981.57.2a, b",0,LEINBERGER HANS
+1982.147.25,0,"Pollock, Jackson"
+1982.16.3,0,"De Kooning, Willem"
+1982.171.1,0,"Kim, Kwang Ju"
+1982.179.29,0,"Derain, André"
+1982.213,0,Kamal Muhammad
+1982.213,1,Muhammad Chand
+1982.30ab,0,"Frankl, Paul T."
+1982.324,0,"Meares, Richard"
+1982.443.2,0,"Powers, Hiram"
+1982.45,0,"Briosco, Andrea, called Riccio"
+"1982.4a, b",0,"Fletcher, Thomas"
+"1982.4a, b",1,"Gardiner, Sidney"
+1982.53,0,Balthus (Balthasar Klossowski)
+1982.55.1,0,"Pippin, Horace"
+1982.59.1–.105,0,"Appleton, Thomas"
+1982.60.129,0,Master of the Martyrdom of St. Sebastian
+1982.60.61,0,"Oeben, Jean-François"
+1982.60.61,1,Vandercruse Roger called Lacroix
+1982.60.81,0,"Roentgen, David"
+1982.60.81,1,"Zick, Januarius"
+1982.60.81,2,Gervais Elie
+1982.60.81,3,"Rémond, Pierre"
+1982.60.82,0,"Boulle, André Charles"
+1982.90.1a-c,0,"Rosenquist, James"
+1983.1009(8),0,"Matisse, Henri"
+1983.251,0,"Botero, Fernando"
+1983.356,0,Donatello
+1983.451,0,"Baldung, Hans (called Hans Baldung Grien)"
+1983.457,0,"Guston, Philip"
+1983.606.14–.22,0,"Warhol, Andy"
+"1983.619.1a, b",0,Saint Laurent Yves
+"1983.619.1a, b",1,"Saint Laurent Yves, Paris"
+"1983.8a, b",0,"Poiret, Paul"
+1984.114.1,0,Vuillaume Jean Baptiste
+"1984.163.4a, b",0,"Saint Laurent Yves, Paris"
+"1984.163.4a, b",1,Saint Laurent Yves
+1984.194,0,"Grooms, Red"
+1984.225,0,"Ertel, Giacomo (Jacob)"
+1984.256,0,Fulper Pottery Company
+1984.3,0,"Chanel, Gabrielle ""Coco"""
+1984.3,1,"Chanel, House of"
+1984.315.42,0,"Klee, Paul"
+1984.328a-d,0,"Caro, Anthony"
+1984.331.13,0,"Munro, Rebekah S."
+1984.34,0,Hofmann Ferdinand
+1984.425,0,"Bennett, John"
+1984.433.16,0,"Matisse, Henri"
+1984.433.294,0,"Schiele, Egon"
+1984.433.298ab,0,"Schiele, Egon"
+1984.433.34,0,"Lachaise, Gaston"
+1984.459.1,0,"Sweerts, Michiel"
+1984.459.2,0,Guercino (Giovanni Francesco Barbieri)
+1984.527,0,"Avery, Milton"
+1984.613.2,0,"De Kooning, Willem"
+1985.114,0,"Lalique, René-Jules"
+1985.116,0,"Pabst, Daniel"
+1985.124,0,Tielke Joachim
+1985.353,0,"Saint-Gaudens, Augustus"
+1985.63.5,0,"Rothko, Mark"
+1986.1053.1,0,"Brandt, Bill"
+1986.1054.19,0,"O'Sullivan, Timothy H."
+1986.1159,0,"Mantegna, Andrea"
+1986.1225.2,0,"Kertész, André"
+1986.138,0,"Lotto, Lorenzo"
+1986.237,0,Boston and Sandwich Glass Company
+1986.239,0,Kintzing Christian
+"1986.265.1, .2",0,Grecke Johan Adolph
+1986.266.4,0,Wu Bin
+1986.353.1,0,"Hauser, Hermann"
+1986.353.2,0,"Ramírez, Manuel"
+1986.365.3,0,Oppenordt Alexandre-Jean
+1986.365.3,1,"Berain, Jean"
+1986.397,0,"Bourgeois, Louise"
+1986.441.3,0,"Still, Clyfford"
+1987.1100.1,0,"Sheeler, Charles"
+1987.1100.10,0,"Strand, Paul"
+1987.1100.13,0,"Coburn, Alvin Langdon"
+1987.1100.384,0,"Abbott, Berenice"
+1987.1100.40,0,Man Ray
+1987.1100.47,0,"Lissitzky, El"
+1987.1100.476,0,"Feininger, T. Lux"
+1987.1100.48,0,"Kertész, André"
+1987.1100.482,0,"Evans, Walker"
+1987.1100.49,0,Umbo (Otto Umbehr)
+1987.1100.87,0,"Model, Lisette"
+1987.1161,0,"Braun, Adolphe"
+1987.12,0,"Müller, Karl L. H."
+1987.282,0,"Close, Chuck"
+1987.455.2,0,"Klee, Paul"
+1987.47.1,0,"Degas, Edgar"
+1987.88,0,"Warhol, Andy"
+1988.103,0,"Evans, Walker"
+1988.1031,0,"Cuvelier, Eugène"
+1988.159,0,"von Hagenau, Nikolaus"
+1988.162,0,Canaletto (Giovanni Antonio Canal)
+1988.164,0,Hukin & Heath
+1988.164,1,"Dresser, Christopher"
+1988.294.1,0,Meissen Manufactory
+1988.294.1,1,Kirchner Johann Gottlieb
+1988.65.1–.2,0,Hallé
+1988.74.2a–e,0,"Gernreich, Rudi"
+1988.87,0,Tecchler David
+1989.1038.2,0,"Klein, William"
+1989.1063,0,"Greene, John Beasley"
+1989.1083,0,"Watkins, Carleton E."
+1989.1135,0,"Strand, Paul"
+1989.147,0,Voboam Jean-Baptiste
+1989.183,0,"Gericault, Théodore"
+1989.197,0,Diehl Charles-Guillaume
+1989.197,1,Frémiet Emmanuel
+1989.197,2,Brandely Jean
+1989.281.72,0,Achilles Painter
+1989.3,0,"Drouart, Jean"
+1989.363.4,0,HUANG TINGJIAN
+1990.1005,0,"Lange, Dorothea"
+1990.103,0,"Sellas, Matteo"
+1990.1083,0,"Metzker, Ray K."
+1990.113,0,"Le Secq, Henri-Jean-Louis"
+1990.223,0,Norman Barak
+1990.226a–d,0,"Revere, Paul, Jr."
+1990.237a-c,0,"Ringgold, Faith"
+1990.247,0,"Pacetti, Vincenzo"
+1990.38.1,0,"Boccioni, Umberto"
+1990.38.3,0,"Boccioni, Umberto"
+1991.1044,0,"Robert, Louis-Rémy"
+1991.1056,0,"Steinert, Otto"
+1991.1127,0,"Fuss, Adam"
+1991.1198,0,Nadar
+1991.1232,0,"Sander, August"
+1991.1233,0,"Atget, Eugène"
+1991.145,0,"Price, William Lightfoot"
+1991.311.1,0,Byrdcliffe Arts and Crafts Colony
+"1991.373a, b",0,Kunitoshi Rai
+1991.77,0,"Murray, Elizabeth"
+1992.128,0,"Guy, Seymour Joseph"
+1992.146,0,"Dix, Otto"
+1992.23,0,American Pottery Manufacturing Company
+1992.24.1,0,"Davis, Stuart"
+1992.24.3,0,"Hartley, Marsden"
+1992.24.8,0,"Sheeler, Charles"
+1992.269,0,"Hunzinger, George Jakob"
+1992.279,0,"de Frías, Joseph"
+1992.333,0,Tielke Joachim
+1992.391,0,"Picasso, Pablo"
+1992.43,0,"de Forest, Lockwood"
+1992.5,0,"Baldus, Édouard"
+1992.5067,0,"Matta-Clark, Gordon"
+1992.51,0,Habiballah
+1992.5107,0,"Winogrand, Garry"
+1992.5147,0,"Sherman, Cindy"
+1992.5149,0,"Steichen, Edward J."
+1992.5152,0,"Atget, Eugène"
+1992.5154,0,"Polke, Sigmar"
+1992.5158,0,"Bustamante, Jean-Marc"
+1992.8,0,Herter Brothers
+"1992.8.1, .2",0,Sesson Shūkei
+1993.1097,0,"Altdorfer, Albrecht"
+1993.132,0,"Gogh, Vincent van"
+1993.14,0,"Tekelü, Ahmed"
+1993.195a–s,0,"Bush, Andrew"
+1993.303a-f,0,"Prutscher, Otto"
+1993.303a-f,1,Beissbarth & Hoffmann
+1993.324,0,"Anshutz, Thomas"
+1993.332.2,0,"Foggini, Giovanni Battista"
+1993.393.1,0,"Balenciaga, Cristobal"
+1993.393.1,1,Balenciaga House of
+1993.400.6,0,"Braque, Georges"
+1993.415,0,"Bernard, Léopold"
+1993.415,1,"Brun, J. C. A."
+1993.415,2,"Tissot, Jean-Claude"
+1993.415,3,"Fannière, François-Auguste"
+1993.415,4,"Fannière, François-Joseph-Louis"
+1993.52.3,0,Versace Gianni
+1993.52.3,1,Gianni Versace
+1993.52.4,0,Versace Gianni
+1993.52.4,1,Gianni Versace
+1993.55,0,Fath Jacques
+1993.55,1,Fath House of Jacques
+1993.69.3,0,"Vallou-de-Villeneuve, Julien"
+1993.7,0,"Dijon, V."
+1993.71,0,"Freud, Lucian"
+1993.75,0,"Davenport, A. H."
+1993.75,1,"Bacon, Francis H."
+1993.96,0,"Yamamoto, Yohji"
+1994.12,0,"Mackintosh, Charles Rennie"
+1994.141,0,"Vali, Mustafa ibn"
+1994.141,1,Sultan Murad III
+1994.141,2,Mustafa b. Yusuf al-Darir al-Erzerumi
+1994.144.8,0,"Sugimoto, Hiroshi"
+1994.182,0,"Johnson, David"
+1994.245.135,0,"Evans, Walker"
+1994.269,0,"Henle, Jan"
+1994.271,0,"Atget, Eugène"
+1994.278,0,Lacroix Christian
+1994.278,1,"Patou, House of"
+1994.417,0,"Choiselat, Marie-Charles-Isidore & Stanislas Ratel"
+1994.417,1,"Ratel, Stanislas"
+1994.45,0,"Hassam, Childe"
+1994.486,0,"Léger, Fernand"
+1994.567,0,"Hassam, Childe"
+"1994.578.3a, b",0,Gaultier Jean Paul
+1994.76,0,"Wiles, Irving Ramsey"
+1994.83,0,Unknown
+1995.101,0,"Fragonard, Jean Honoré"
+1995.12,0,"Orley, Bernard van"
+1995.13,0,"Bakewell, Page & Bakewell"
+1995.14.5,0,"Kiefer, Anselm"
+1995.142,0,"Dubuffet, Jean"
+1995.15,0,"Brueghel, Jan, the Elder"
+1995.191,0,"Gursky, Andreas"
+1995.196,0,"Ruisdael, Jacob van"
+1995.213a–h,0,"Westwood, Vivienne"
+1995.234,0,"Baziotes, William"
+1995.245.1,0,Valentina
+1995.251,0,"Warhol, Andy"
+1995.336,0,"Colt, Samuel"
+"1995.371a, b",0,Mekeren Jan van
+1995.377.1,0,"Lannuier, Charles-Honoré"
+1995.378,0,"Homer, Winslow"
+1995.440a-c,0,"Zeisel, Eva"
+1995.440a-c,1,Schramberg Majolica Factory
+1995.474,0,"Ray, Charles"
+1995.595,0,"Krasner, Lee"
+1995.72.7,0,Teng Yeohlee
+1995.96.10,0,"Bacot, Edmond"
+1996.102,0,"Coleman, Charles Caryl"
+1996.13.1,0,"Oberlender, Johann Wilhelm"
+1996.14,0,"Gerhaert von Leyden, Niclaus"
+1996.279,0,"Copley, John Singleton"
+1996.291a–c,0,"Callahan, Harry"
+1996.297,0,"Struth, Thomas"
+1996.299,0,"Arbus, Diane"
+1996.322,0,"Woodman, Francesca"
+1996.363.2,0,"Robert, Louis-Rémy"
+"1996.364a, b",0,"Verona, Stefano da"
+1996.382,0,"Hassam, Childe"
+1996.403.1,0,"Picasso, Pablo"
+1996.403.10,0,"Chirico, Giorgio de"
+1996.403.7ab,0,"Brancusi, Constantin"
+1996.403.8,0,"Miró, Joan"
+1996.418,0,"Gauguin, Paul"
+1996.480.3,0,Halston
+1996.558,0,Olowe of Ise
+1996.561,0,"Proctor, Alexander Phimister"
+1996.563,0,"Benbridge, Henry"
+1996.99.2,0,"Cameron, Julia Margaret"
+1997.108,0,"Faigenbaum, Patrick"
+1997.117.10,0,"Ostade, Adriaen van"
+1997.149.12,0,"Braque, Georges"
+1997.149.9,0,"Modigliani, Amedeo"
+1997.153,0,Raphael (Raffaello Sanzio or Santi)
+1997.156,0,Claude Lorrain (Claude Gellée)
+1997.167,0,Caravaggio (Michelangelo Merisi)
+1997.195,0,"Fuss, Adam"
+1997.207,0,"Cassatt, Mary"
+1997.228,0,Itoh Takuo
+1997.25,0,"Strand, Paul"
+1997.250.6,0,Kang Ji
+1997.36,0,Polyteleia Painter
+1997.382.1,0,"Talbot, William Henry Fox"
+1997.382.19,0,"Hill, David Octavius"
+1997.382.19,1,"Adamson, Robert"
+1997.382.19,2,Hill and Adamson
+1997.382.34,0,"Fenton, Roger"
+1997.382.35,0,"Fenton, Roger"
+1997.382.38,0,"Cameron, Julia Margaret"
+1997.382.41,0,"Whipple, John Adams"
+1997.382.46,0,"Moulin, Félix-Jacques-Antoine"
+1997.460.1a–d,0,MEMPHIS MILANO
+1997.460.1a–d,1,"Sottsass, Ettore"
+1997.4ab,0,"Kiefer, Anselm"
+1997.61.19,0,"Stieglitz, Alfred"
+1997.61.25,0,"Stieglitz, Alfred"
+1997.93,0,"Spranger, Bartholomeus"
+1998.121,0,"Pons, Joseph"
+1998.132,0,"Nègre, Charles"
+1998.21,0,"Ingres, Jean Auguste Dominique"
+1998.21,1,"Kaunitz-Rietberg, Prince Wenzel von"
+1998.225,0,"Poussin, Nicolas"
+1998.311.1,0,"Smith, David"
+1998.329,0,"Johns, Jasper"
+1998.338,0,"Chauvassaignes, Franck-François-Genès"
+1998.365,0,"Sargent, John Singer"
+1998.431.1a–e,0,"Rosenquist, James"
+1998.431.1a–e,1,Hugo Boss
+1998.479,0,Simca Print Artists Inc.
+1998.479,1,"Johns, Jasper"
+"1998.493.189a, b",0,Sant'Angelo Giorgio
+1998.57,0,"Tournachon, Adrien"
+1998.57,1,Nadar
+1998.57,2,"Deburau, Jean-Charles"
+1998.7,0,Pere Alexandre & Fils
+1999.103,0,Ezra
+1999.176,0,"Dewing, Thomas Wilmer"
+1999.18,0,"Mead, Larkin Goldsmith"
+1999.19,0,"Farrer, Henry"
+1999.2,0,"Muniz, Vik"
+1999.21,0,"Ruff, Thomas"
+1999.222,0,"Rubens, Peter Paul"
+1999.237.4,0,"Evans, Walker"
+1999.24,0,"Rovner, Michal"
+1999.26,0,Amati Andrea
+1999.27.1a-c-5,0,"Saarinen, Eliel"
+1999.27.1a-c-5,1,WILCOX SILVER
+"1999.307 a,b",0,"Porthaux, Dominique Antony"
+1999.363.15,0,"Chirico, Giorgio de"
+1999.363.16,0,"Dalí, Salvador"
+1999.363.20,0,"Dubuffet, Jean"
+1999.363.22,0,"Giacometti, Alberto"
+1999.363.41,0,"Matisse, Henri"
+1999.363.50,0,"Miró, Joan"
+1999.363.53,0,"Miró, Joan"
+1999.38,0,"Abbott, Berenice"
+1999.396,0,"Belter, J. H."
+1999.399,0,"Adhikari, Murari"
+1999.494a–h,0,Galliano John
+1999.494a–h,1,"Dior, House of"
+1999.58a–d,0,"Jacobs, Marc"
+1999.58a–d,1,Vuitton Louis
+1999.93,0,Prince Lu
+20.155.1,0,"Gainsborough, Thomas"
+20.155.11,0,"Riesener, Jean Henri"
+20.155.3,0,"Reynolds, Joshua, Sir"
+20.155.8,0,"Greuze, Jean-Baptiste"
+20.155.9,0,"Boucher, François"
+20.24.76,0,"Peruzzi, Baldassare Tommaso"
+20.24.76,1,"Carpi, Ugo da"
+2000.127,0,"Lonberg-Holm, Knud"
+2000.13,0,"Le Gray, Gustave"
+2000.151,0,"Peale, Rembrandt"
+2000.272,0,"Prince, Richard"
+2000.278.1-.9,0,"Hoffmann, Josef"
+2000.278.1-.9,1,Wiener Werkstätte
+2000.51,0,"Friedrich, Caspar David"
+2000.512,0,"Whistler, James McNeill"
+2000.600.15,0,"Rohde, Gilbert"
+2000.600.15,1,"Miller, Herman Inc."
+2000.63a-c,0,"Brandt, Marianne"
+2001.153,0,"Hannock, Stephen"
+2001.293,0,"Smithson, Robert"
+2001.402a,0,"Tanner, Henry Ossawa"
+2001.474,0,"Arbus, Diane"
+2001.608.1,0,"Homer, Winslow"
+2001.641,0,"Saint-Gaudens, Augustus"
+2001.642,0,Bamen Tomotsugu
+2001.723,0,"Fouquet, Georges"
+"2001.742a, b",0,Comme des Garçons
+"2001.742a, b",1,Watanabe Junya
+2002.1,0,"West, Benjamin"
+2002.115,0,Imperial Armory
+2002.190a–n,0,Courtois frères
+2002.21.1,0,"Rush, William"
+2002.259,0,"Kilburn, (or Kilbrunn) Lawrence"
+2002.26,0,"Friedrich, Caspar David"
+2002.323 a-f,0,Langenbucher Veit
+2002.323 a-f,1,"Bidermann, Samuel"
+2002.365,0,"Ruhlmann, Émile-Jacques"
+2002.365,1,"Gaudissard, Emile"
+2002.436,0,"Lorenzetti, Pietro"
+2002.456.1,0,"Carrington, Leonora"
+2002.456.111,0,"Giacometti, Alberto"
+2002.468,0,Permoser Balthasar
+"2003.12a, b",0,Studio 65
+"2003.12a, b",1,Gufram
+2003.150a–g,0,Esposito Giosue
+2003.241,0,'Abd al-Qadir Hisari
+2003.269,0,"Hammons, David"
+2003.27,0,"Matta, Roberto"
+2003.323,0,"Graf, Urs"
+2003.442,0,Gucci
+2003.442,1,Ford Tom
+2003.462,0,Alexander McQueen
+2003.462,1,McQueen Alexander
+2003.63a–d,0,Unknown
+"2003.68a, b",0,Armani Giorgio
+2004.442,0,Duccio di Buoninsegna
+2005.100.1,0,"Aguado de las Marismas, Onésipe"
+2005.100.109,0,"Watkins, Carleton E."
+2005.100.116,0,"Seeley, George H."
+2005.100.140,0,Man Ray
+2005.100.27,0,"Cameron, Julia Margaret"
+2005.364.1a–d–.48,0,Fourteen identified German (Augsburg) goldsmiths and other Germa
+2005.365,0,Garion
+2005.390a-c,0,"Rauschenberg, Robert"
+2005.44.2,0,Adrover Miguel
+2006.277a-fff,0,"Tinguely, Jean"
+2006.32.15,0,"Ernst, Max"
+2006.32.49,0,"Oldenburg, Claes"
+2006.32.5,0,"Calder, Alexander"
+"2006.420.51a, b",0,Saint Laurent Yves
+"2006.420.51a, b",1,"Saint Laurent Yves, Paris"
+2006.452a–c,0,Redlin Michel
+"2006.519a, b",0,"Dugourc, Jean Démosthène"
+"2006.519a, b",1,"Pernon, Camille"
+2006.86a–c,0,"Scherer, Georg Henrich"
+2006.91,0,"Wall, Jeff"
+2007.194a–f,0,Teijo Goto
+2007.194a–f,1,Gotō Yūjō
+2007.27,0,"Hoentschel, Georges"
+2007.27,1,Grittel Èmile
+2007.329,0,Unidentified Artist
+2007.442,0,"Voiriot, Guillaume"
+2007.95,0,"Hepworth, Barbara"
+2007.96,0,"Anatsui, El"
+2008.1,0,Grancino Giovanni
+2008.121,0,"Anatsui, El"
+2008.253,0,"Leyden, Lucas van"
+2008.278,0,Hans of Landshut
+2008.29,0,"Kapoor, Anish"
+2008.312,0,Bhawani Das
+2008.459,0,Valentin de Boulogne
+2008.547.1,0,"Gérôme, Jean-Léon"
+2009.28,0,Anonymous
+2009.28,1,"Amman, Jost"
+2009.28,2,Anonymous Flemish weavers
+2009.300.816,0,James Charles
+2009.58,0,"Briosco, Andrea, called Riccio"
+2009.8a–c,0,"Jackson, Samuel"
+201.9 Av3,0,"Avery, Samuel Putnam, Sr."
+201.9Av3 Av32,0,"Avery, Samuel Putnam, Sr."
+201.9F88 B73,0,Brainerd Ira Hutchinson
+2010.121,0,"Struth, Thomas"
+2010.138.1-.4,0,Bunsen Franz Peter
+2010.23,0,"Gros, Jean-Baptiste-Louis"
+2010.24,0,"Messerschmidt, Franz Xaver"
+2010.466,0,"Fitch, Julia Ann"
+2011.36,0,Perino del Vaga (Pietro Buonaccorsi)
+2012.99,0,"Bassano, Jacopo (Jacopo da Ponte)"
+2014.173,0,"Enríquez, Nicolás"
+2014.269,0,"Rodríguez Juárez, Juan"
+21.115.4,0,"Whittredge, Worthington"
+21.164,0,"Glackens, William James"
+216.7 T71,0,"Andrews, William Loring"
+216.7 T71,1,Berners Juliana
+217.08  W881,0,Woolnough Charles W.
+22.16.17,0,"Cassatt, Mary"
+"22.19a, b",0,"Targee, John"
+22.207,0,"Homer, Winslow"
+22.61,0,"MacMonnies, Frederick William"
+22.75,0,"Sarto, Andrea del (Andrea d'Agnolo)"
+221.1 K63,0,Kirchner Athanasius
+226 B641,0,"Buonanni, Filippo"
+23.101,0,"Cassatt, Mary"
+23.102,0,"Healy, George P. A."
+23.163.4a,0,"Morris, William"
+23.163.4a,1,Morris & Company
+23.163.4a,2,Jeffrey & Co.
+23.31.1,0,"Picasso, Pablo"
+23.31.1,1,"Fort, Louis"
+23.31.1,2,"Vollard, Ambroise"
+230.51 N55,0,Tong zhi tang
+230.51 N55,1,"Nie, Chongyi"
+239 B63 Q,0,Boch Jean
+239 B63 Q,1,"Borcht, Peeter van der"
+"24.179; 26.188.1, .2; 29.158.363a, b",0,"Helmschmid, Kolman"
+24.197.2,0,Michelangelo Buonarroti
+24.241.2,0,Toft Thomas
+24.45.1,0,"Poussin, Nicolas"
+24.97.104,0,Tarporley Painter
+240.7 T344 F,0,Elseviers
+240.7 T344 F,1,Boslwert A.
+240.7 T344 F,2,Thibault Girard
+25.115.15,0,"Armitt, Joseph"
+25.120.288,0,Bartolo di Fredi
+25.17,0,"Ostendorfer, Michael"
+25.17,1,"Apianus, Petrus"
+25.17,2,"Apianus, Georg and Petrus"
+25.231.1,0,"Ruhlmann, Émile-Jacques"
+25.78.56,0,Polykleitos
+250 T34,0,"Dézallier d'Argenville, Antoine Joseph"
+254 B63,0,"Böckler, Georg Andreas"
+26.117,0,Kōrin
+26.12,0,"French, Daniel Chester"
+"26.145.243a, b",0,"Deutschmann, Joseph"
+"26.145.315a, b",0,Morisset James
+26.168.77,0,"Biennais, Martin-Guillaume"
+26.168.77,1,"Percier, Charles"
+26.168.77,2,Jacob-Desmalter François-Honoré-Georges
+26.168.77,3,"Denon, Dominique Vivant Baron"
+26.49,0,Nearchos
+26.54,0,Webb Philip
+26.54,1,"Burne-Jones, Edward, Sir"
+26.54,2,"Morris, Marshall, Faulkner & Co."
+26.72.68,0,"Altdorfer, Albrecht"
+26.9,0,"Böcklin, Arnold"
+26.97,0,"Johnson, Eastman"
+27.137,0,"Zurbarán, Francisco de"
+270.52 T49,0,"Hunter, Dard"
+270.52 T49,1,"Tindale, Thomas & Harriet R."
+272.4 Au8,0,"Avery, Samuel Putnam, Sr."
+273.4 G76,0,"Grand-Carteret, John"
+273.4 G76,1,"Régamey, Félix"
+273.4D26 AL2,0,"Daumier, Honoré"
+273.4D26 AL2,1,"Alexandre, Arsène"
+28.221,0,"Cranach, Lucas, the Elder"
+"28.52a, b",0,New Bremen Glass Manufactory 
+"28.52a, b",1,"Amelung, John Frederick"
+28.57.23,0,Persephone Painter
+29.100.115,0,"Manet, Édouard"
+29.100.129,0,"Daumier, Honoré"
+29.100.16,0,Bronzino (Agnolo di Cosimo di Mariano)
+29.100.200,0,"Daumier, Honoré"
+29.100.23,0,"Ingres, Jean Auguste Dominique"
+29.100.370,0,"Degas, Edgar"
+29.100.370,1,HÉBRARD A. A.
+29.100.5,0,"Greco, El (Domenikos Theotokopoulos)"
+29.100.53,0,"Manet, Édouard"
+29.100.565,0,"Corot, Camille"
+29.100.57,0,"Courbet, Gustave"
+29.100.6,0,"Greco, El (Domenikos Theotokopoulos)"
+29.100.66,0,"Cézanne, Paul"
+29.100.939,0,Rembrandt (Rembrandt van Rijn)
+29.107.28,0,Rembrandt (Rembrandt van Rijn)
+3.3,0,"Delacroix, Eugène"
+30.5,0,"La Farge, John"
+31.109,0,"Copley, John Singleton"
+31.11.10,0,Amasis Painter
+31.11.11,0,Lydos
+31.11.13,0,Eretria Painter
+31.11.5,0,Epimenes
+31.45,0,"David, Jacques Louis"
+31.62,0,"Hopper, Edward"
+32.100.43,0,Rogier van der Weyden
+32.12,0,Rose Joseph
+32.12,1,Gilbert John
+32.12,2,John Devall & Co.
+32.12,3,"Adam, Robert"
+32.130.2,0,"Mantegna, Andrea"
+32.130.6a–y,0,"Halder, Jacob"
+33.120.221,0,"Winslow, Edward"
+33.164a–x,0,"Lochner, Kunz"
+33.165.1,0,"Germain, François Thomas"
+33.23,0,de Werve Claus
+33.43.132,0,"Käsebier, Gertrude"
+33.43.303,0,"White, Clarence H."
+33.43.334,0,"Strand, Paul"
+33.43.343,0,"Sheeler, Charles"
+33.43.36,0,"Steichen, Edward J."
+33.43.39,0,"Steichen, Edward J."
+33.43.43,0,"Steichen, Edward J."
+33.43.44,0,"Steichen, Edward J."
+33.43.47,0,"Steichen, Edward J."
+33.61,0,"Bingham, George Caleb"
+"33.65.11, .226",0,"Gardner, Alexander"
+"33.65.11, .226",1,"Brady, Mathew B."
+33.7,0,Abu'l Qasim Firdausi
+33.92ab,0,"Eyck, Jan van"
+34.100.124,0,"Roth, Heinrich"
+34.134,0,"La Farge, John"
+34.138,0,"Watteau, Antoine"
+34.73,0,"Ribera, Jusepe de (called Lo Spagnoletto)"
+34.86.1 a,0,"Stradivari, Antonio"
+34.86.2 a,0,"Stradivari, Antonio"
+34.92,0,"Eakins, Thomas"
+35.27,0,"Schongauer, Martin"
+35.42,0,Goya (Francisco de Goya y Lucientes)
+"36.120.417a, b, .418a–c",0,Sukemitsu of Bizen
+"36.120.417a, b, .418a–c",1,Yasumitsu
+"36.120.417a, b, .418a–c",2,Iwamoto Konkan
+36.120.79,0,Ishiguro Masayoshi
+36.14a–c,0,"Patinir, Joachim"
+36.37 (25),0,"Talbot, William Henry Fox"
+37.165.107,0,"Watteau, Antoine"
+37.45.3(27),0,"Piranesi, Giovanni Battista"
+37.45.3(27),1,"Bouchard, Giovanni"
+38.34,0,"Southworth, Albert Sands"
+38.34,1,"Hawes, Josiah Johnson"
+38.34,2,Southworth and Hawes
+38.59,0,"Furman, Warner Williams Sarah"
+38.63,0,"Kierstede, Cornelius"
+39.121a–n,0,"Cousin, Jean, the Elder"
+39.121a–n,1,"Delaune, Étienne"
+39.121a–n,2,"Pellerin, Baptiste"
+39.153,0,"Maiano, Giuliano da"
+39.153,1,Francesco di Giorgio Martini
+39.153,3,Benedetto da Maiano
+39.52,0,"Peale, James"
+39.65.53,0,"Saint-Gaudens, Augustus"
+39.68.27,0,"Lucas, David"
+39.68.27,1,"Constable, John"
+41.1.31,0,Rembrandt (Rembrandt van Rijn)
+41.100.132,0,de Liège Jean
+41.100.23,0,"Martini, Simone"
+41.138,0,Unidentified Artist
+41.82,0,"Roentgen, David"
+41.82,1,"Zick, Januarius"
+41.82,2,"Chippendale, Thomas"
+42.154,0,"Curry, John Steuart"
+42.155,0,"Blume, Peter"
+42.167,0,"Lawrence, Jacob"
+42.22,0,"Kuntz, Jacob"
+42.50.16,0,"Treviso, Girolamo da"
+42.50.2,0,LIONARDO
+43.106.1,0,"Dürer, Albrecht"
+43.13,0,"Murillo, Bartolomé Estebán"
+43.159.1,0,"Benton, Thomas Hart"
+43.86.4,0,"Copley, John Singleton"
+43.87.17,0,"Eakins, Thomas"
+43.87.23,0,"Eakins, Thomas"
+"44.21a, b",0,Clodion (Claude Michel)
+45.128.5,0,Pesquera Diego de
+45.62.1,0,"Morse, Samuel F. B."
+"46.140.767a, b",0,Boston and Sandwich Glass Company
+46.16,0,"Poussin, Nicolas"
+46.192.4,0,"Smith, John Rubens"
+46.25.1a–d,0,"Worth, Charles Frederick"
+46.25.1a–d,1,"Worth, House of"
+46.43.4,0,"Le Brun, Charles"
+46.43.4,1,Lemoyen le Lorrain Jean
+46.43.4,2,"Convent of Saint Joseph-de-la-Providence, Paris"
+46.43.4,3,Montespan Marquise de
+47.106,0,"Picasso, Pablo"
+47.26,0,"Burne-Jones, Edward, Sir"
+48.190.2,0,"Gogh, Vincent van"
+48.81,0,"Miller, Sally"
+49.12,0,"Copley, John Singleton"
+49.24,0,"Chardin, Jean Siméon"
+49.3,0,"Gogh, Vincent van"
+49.38,0,"Fouquet, Jean"
+49.55.327,0,"de Meyer, Adolf"
+49.55.35,0,"Stieglitz, Alfred"
+49.59.1,0,"Demuth, Charles"
+49.7.10,0,"Lippi, Filippino"
+49.7.108,0,LIMOSIN LÉONARD
+49.7.16,0,Titian (Tiziano Vecellio)
+49.7.19,0,"Christus, Petrus"
+49.7.21,0,"David, Gerard"
+49.7.41,0,Goya (Francisco de Goya y Lucientes)
+49.7.49,0,"Fragonard, Jean Honoré"
+49.70.1,0,"Kandinsky, Vasily"
+49.70.105,0,"Marin, John"
+49.70.42,0,"Hartley, Marsden"
+50.102.4,0,"Soudbinine, Séraphin"
+50.102.4,1,"Dunand, Jean"
+50.11.4,0,Group of Boston 00.348
+50.117,0,"Wood, Grant"
+50.135.4,0,"Holbein, Hans, the Younger"
+50.135.5,0,"Lawrence, Thomas, Sir"
+50.145.66,0,"Houdon, Jean Antoine"
+50.145.8,0,"Constable, John"
+50.164,0,Riza-yi `Abbasi
+50.228.3,0,"Gardner, Caleb"
+50.583.4,0,"Dyck, Anthony van"
+51.112.1,0,"Cézanne, Paul"
+51.112.2,0,"Gauguin, Paul"
+51.112.5,0,"Rousseau, Henri (le Douanier)"
+51.33.2,0,"Toulouse-Lautrec, Henri de"
+51.56,0,Ja'far ibn Muhammad ibn `Ali
+51.9,0,Leonardo da Vinci
+52.184,0,"Vanderlyn, John"
+52.203,0,"O'Keeffe, Georgia"
+52.81,0,Caravaggio (Michelangelo Merisi)
+526 R82,0,Royal Asiatic Society
+526 R82,1,Cambridge University Press
+53.223,0,"Sax, Charles Joseph"
+53.225.52,0,"Palissy, Bernard"
+53.56.11,0,"Richters, Hendrik"
+53.87a-i,0,"Noguchi, Isamu"
+53.9,0,"Davis, Stuart"
+532 Eg961,0,"Belzoni, Giovanni Battista"
+532 L551,0,"Lepsius, Richard"
+532 L551,1,"Naville, Édouard F."
+532 L551,2,"Borchardt, Ludwig"
+"54.1.1a, b",0,The Limbourg Brothers
+54.1.2,0,PUCELLE JEAN
+54.167,0,"Myers, Myer"
+543.1N48 M97 Q,0,Curtius Ernst
+543.1N48 M97 Q,1,"Cesnola, Luigi Palma di"
+55.119,0,Claude Lorrain (Claude Gellée)
+55.121.10.22,0,Govardhan
+55.121.10.22,1,Mir 'Ali Haravi
+55.121.10.24,0,Chitarman
+55.44,0,"Ibn al-Suhrawardi al-Bakri, Ahmad"
+55.44,1,Muhammad ibn Aibak ibn 'Abdallah
+55.86 a-c,0,"Stradivari, Antonio"
+55.93,0,"Antico (Alari Bonacolsi, Pier Jacopo)"
+551 G41,0,"Apvd Gvlielmvm, svb scvto veneto"
+551 G41,1,"Gilles, Pierre"
+56.105,0,"Pajou, Augustin"
+56.11.1,0,Amasis Painter
+56.171.38,0,Berlin Painter
+56.171.64,0,Lycurgus Painter
+56.205.1,0,"Gorky, Arshile"
+56.228,0,"Brugghen, Hendrick ter"
+56.70a–c,0,"Campin, Robert"
+57.130.7,0,"Belter, J. H."
+57.51.21,0,'Abdullah ibn al-Fadl
+57.51.23,0,Badi' al-Zaman ibn al-Razzaz al-Jazari
+57.51.23,1,Farrukh ibn `Abd al-Latif
+57.51.26,0,Shah Quli
+57.92,0,"Pollock, Jackson"
+58.57a–d,0,"Vignola, Jacopo [Giacomo] Barozzi da"
+58.57a–d,1,"Porta, Guglielmo della"
+58.57a–d,2,Mynardo Giovanni
+58.75.1–.22,0,Rose Joseph
+58.75.1–.22,1,"Boucher, François"
+58.75.1–.22,2,Manufacture Nationale des Gobelins
+58.75.1–.22,3,"Jacques, Maurice"
+58.75.1–.22,4,"Tessier, Louis"
+58.75.1–.22,5,Mayhew John
+58.75.1–.22,6,Ince William
+58.75.1–.22,7,"Neilson, Jacques"
+58.75.1–.22,8,"Soufflot, Jacques Germain"
+58.75.1–.22,9,"Wilton, Joseph"
+58.75.1–.22,10,Wildsmith John
+58.75.1–.22,11,Blockley Thomas
+58.75.1–.22,12,"Alken, Sefferin"
+58.75.1–.22,13,Langlois Peter
+58.75.1–.22,14,"Hobcraft, John"
+58.75.1–.22,15,Ince and Mayhew
+58.75.1–.22,16,"Adam, Robert"
+58.75.25,0,Baudoin Joseph-François-Xavier
+58.75.25,1,"Jacob, Georges"
+58.75.88a–c,0,"Dodin, Charles Nicolas"
+58.75.88a–c,1,"Duplessis, Jean-Claude"
+58.75.88a–c,2,Sèvres Manufactory
+58.89,0,"Steen, Jan"
+59.12,0,"Turner, Joseph Mallord William"
+59.166,0,"Peale, Raphaelle"
+59.76,0,"Blake, George Henry"
+59.76,1,Érard
+6.1234,0,"Homer, Winslow"
+6.1312,0,Nunns Robert
+6.1312,1,Clark John
+6.306,0,"Vonnoh, Bessie Potter"
+6.311,0,Kephisodotos
+"60.29.1a, b",0,"Fisher, Robert"
+60.3,0,"La Tour, Georges de"
+60.4.1,0,"Phyfe, Duncan"
+60.87,0,"Picasso, Pablo"
+61.101.1,0,"Cézanne, Paul"
+61.101.16,0,"Seurat, Georges"
+61.101.17,0,"Seurat, Georges"
+61.198,0,Rembrandt (Rembrandt van Rijn)
+61.200.1,0,Master of the Codex of Saint George
+62.126,0,"Castiglione, Giovanni Benedetto (Il Grechetto)"
+62.16,0,"McIntire, Samuel"
+62.189,0,Workshop of Biduinus
+62.256.3,0,"Hicks, Edward"
+62.55,0,"Houdon, Jean Antoine"
+62.79.1,0,"Smibert, John"
+62.79.2,0,"Smibert, John"
+62.95,0,"Hopper, Edward"
+62.96,0,de Touyl Jean
+63.1,0,"David, Jacques Louis"
+63.11.6,0,Andokides
+63.11.6,1,Andokides Painter
+63.11.6,2,Lysippides Painter
+63.178.1,0,Muslim Ibn al-Dahhan
+63.201.1,0,"Hathaway, Rufus"
+63.210.11,0,Farid al-Din `Attar
+63.210.11,1,Habiballah
+63.350.246.206.378,0,American Tobacco Company
+63.4,0,Martínez Montañés Juan
+63.73,0,"Kelly, Ellsworth"
+64.148,0,"Klimt, Gustav"
+64.79,0,Cobb John
+64.79,1,"Vile, William"
+65.167.6,0,"Finlay, John"
+65.167.6,1,"Finlay, Hugh"
+65.247,0,"Motherwell, Robert"
+65.47,0,"Imperial Porcelain Manufactory, St. Petersburg"
+65.49,0,"Beaux, Cecilia"
+66.113,0,"Cropsey, Jasper Francis"
+66.126,0,"Mount, William Sidney"
+66.143,0,"La Farge, John"
+66.244.1-.25,0,"Lévy-Dhurmer, Lucien"
+67.110.1,0,"Canova, Antonio"
+67.110.1,1,Tarnowski Jan and Valeria Count and Countess
+67.187.121,0,"Bellows, George"
+67.187.123,0,"Chase, William Merritt"
+67.187.53a-c,0,"Beckmann, Max"
+67.197,0,Lemoyne Jean-Louis
+67.232,0,"Louis, Morris"
+67.241,0,"Monet, Claude"
+67.25,0,"Carpeaux, Jean-Baptiste"
+67.855,0,"Aetna Silkscreen Products, Inc."
+67.855,1,Du-Art Displays
+67.855,2,"Warhol, Andy"
+67.855,3,Factory Additions
+68.1,0,"Bonnard, Pierre"
+68.100.1,0,"Roux, Alexander"
+68.141.81a–f,0,Pantin Simon I
+68.148,0,Bastis Master
+68.185,0,"Graham, John"
+69.113,0,"Robbia, Andrea della"
+"69.140a, b",0,Herter Brothers
+69.27,0,Hatifi
+69.27,1,Suzi
+69.88,0,"Siloe, Gil de"
+7.122,0,"Renoir, Auguste"
+7.123,0,"Bierstadt, Albert"
+7.16,0,"Stuart, Gilbert"
+7.79,0,"Remington, Frederic"
+72.3,0,"Powers, Hiram"
+74.24,0,"Kensett, John Frederick"
+75.7.2,0,Piero di Cosimo (Piero di Lorenzo di Piero d'Antonio)
+"77.9a, b",0,"Whitehouse, James Horton"
+"77.9a, b",1,Tiffany & Co.
+"77.9a, b",2,"Soligny, Eugene J."
+"77.9a, b",3,"Saint-Gaudens, Augustus"
+8.228,0,"Cole, Thomas"
+80.1.2,0,"Richards, William Trost"
+87.25,0,"Bonheur, Rosa"
+87.8.8,0,"Inness, George"
+88.5a–d,0,"Story, William Wetmore"
+89.15.19,0,"Lippi, Fra Filippo"
+89.15.21,0,"Vermeer, Johannes"
+89.21.1,0,"Bastien-Lepage, Jules"
+89.4.1097,0,"Naeplaesnigg, Andreas"
+89.4.1191,0,"Hauslaib, Lorenz"
+89.4.1191,1,"Cuntz, Steffan"
+89.4.1196,0,Grouwels Lodewijck
+89.4.1219,0,Cristofori Bartolomeo
+89.4.1236,0,Hayashi Kodenji
+89.4.2058,0,Sioux
+89.4.2375,0,Haas Johann Wilhelm
+"89.4.2631 a, b",0,Athabascan Family
+"89.4.28 a, b",0,Elevated Tone Workshop
+89.4.2883,0,"Voll, Georg"
+89.4.2929a–e,0,"Todini, Michele"
+89.4.2929a–e,1,"Onofri, Basilio"
+89.4.2929a–e,2,"Reiff, Jacob"
+89.4.909,0,"Gahn, Johann Benedikt"
+89.4.912,0,"Boekhout, Thomas Coenraet"
+89.4.924,0,Claude Laurent
+89.4.926,0,Ganda
+9.95,0,"Church, Frederic Edwin"
+903.6 R541 F,0,"Haghe, Louis"
+903.6 R541 F,1,Croly George Rev.
+903.6 R541 F,2,"Roberts, David"
+91.1.535a–h,0,‘Umar ibn Yusuf ibn ‘Umar ibn ‘Ali ibn Rasul al-Muzaffari
+911.1. M362,0,Martinellie Domenico
+912.1 K63 Q,0,Kirchner Athanasius
+912.63 D23,0,"Dapper, Olfert"
+916.3 An4 F,0,Angas George French
+920.3 W52 F,0,"Westmacott, Richard, Sir"
+920.84 M292,0,Malory Thomas Sir
+920.84 M292,1,"Beardsley, Aubrey Vincent"
+926.1 M642,0,"Milton, John"
+94.14,0,"Powers, Hiram"
+94.4.172,0,"Wedgwood and Sons, Josiah"
+94.9.3,0,"Palmer, Erastus Dow"
+959.9 M292,0,Malthus Francis
+96.17.10,0,"Tiffany, Louis Comfort"
+96.17.10,1,Tiffany Glass and Decorating Company
+96.29,0,"Turner, Joseph Mallord William"
+97.13.1,0,"Crawford, Thomas"
+97.19,0,"MacMonnies, Frederick William"
+97.29.3,0,"Pratt, Matthew"
+97.33,0,"Peale, Charles Willson"
+97.34,0,"Leutze, Emanuel"
+99.2,0,Tiffany & Co.
+99.2,1,"Curran, John T."
+99.31,0,"Turner, Joseph Mallord William"
+AE25 .E53 1751 Q,0,Briasson
+AE25 .E53 1751 Q,1,"Diderot, Denis"
+AE25 .E53 1751 Q,2,"Alembert, Jean Le Rond d'"
+AE25 .E531 1762 Q,0,"Mouchon, Pierre"
+AE25 .E531 1762 Q,1,Briasson
+AE25 .E531 1762 Q,2,"Alembert, Jean Le Rond d'"
+AE25 .E531 1762 Q,3,"Diderot, Denis"
+AE25 .E532 1758 Q,0,"Diodati, Ottaviano"
+AE25 .E532 1758 Q,1,"Giuntini, Vincenzo"
+AE25 .E532 1758 Q,2,"Alembert, Jean Le Rond d'"
+AE25 .E532 1758 Q,3,"Diderot, Denis"
+AE25 .E533 1765 Q,0,"Giuntini, Vincenzo"
+AE25 .E533 1765 Q,1,"Diderot, Denis"
+AY831 .Z7 1783,0,"Houry, Laurent Charles d'"
+AY831 .Z7 1784,0,"Hérissant, La Veuve"
+AY831 .Z7 1784,1,"Collombat, Jacques"
+AY831 .Z7 1784a,0,"Houry, Laurent Charles d'"
+AY831 .Z7 1788,0,"Houry, Laurent Charles d'"
+AY831 .Z7 1792,0,"Houry, Laurent Charles d'"
+AY831 .Z7 1792,1,Imprimerie de Testu
+BF207 .L4 1972,0,"Alpert, Richard"
+BF207 .L4 1972,1,"Metzner, Ralph"
+BF207 .L4 1972,2,"Leary, Timothy"
+BF209.M4 M5313 1963,0,"Michaux, Henri"
+BS75 1785b Q,0,"Didot, François Ambroise"
+BS75 1785b Q,1,"Gibbs, Josiah W. (Josiah Willard)"
+BV4823 .D48 1741,0,"Humblot, Antoine"
+BV4823 .D48 1741,1,"Guélard, J. B."
+BV4823 .D48 1741,2,"Duflos, Claude"
+BV4834 .A75 1696,0,Arndts Johan
+BX2010 .A2 1794,0,"Mazzinelli, Alessandro"
+BX2010 .A2 1794,1,"Pacetti, Giovanni Battista"
+BX2010 .A2 1794,2,Catholic Church
+BX2010 .A2 1794,3,"Passeri, Giuseppe"
+BX2010 .A2 1794,4,"Carracci, Annibale"
+BX2010 .A2 1794,5,Salvioni
+BX2016.A5 F7 1792,0,Catholic Church
+BX2016.A5 F7 1792,1,Langlois
+BX9454 .S25 1688,0,Arnold Seneuse
+BX9454 .S25 1688,1,Denis de Sainte-Marthe
+C.I.42.33.3,0,"Molyneux, Edward"
+C.I.44.64.8a–c,0,"Chanel, Gabrielle ""Coco"""
+C.I.44.64.8a–c,1,"Chanel, House of"
+"C.I.45.27a, b",0,Maison Léoty
+"C.I.46.4.18a, b",0,"Lanvin, Jeanne"
+"C.I.46.4.18a, b",1,"Lanvin, House of"
+C.I.46.4.20a–c,0,"Worth, House of"
+"C.I.46.57a, b",0,Rosenstein Nettie
+C.I.50.110a–j,0,Mainbocher
+C.I.50.44,0,"Fortuny, Mariano"
+C.I.50.44,1,Fortuny
+C.I.51.83,0,Schiaparelli Elsa
+C.I.52.18.4,0,"Vionnet, Madeleine"
+C.I.52.5.2,0,Reboux Caroline
+C.I.53.40.7a–e,0,"Dior, Christian"
+C.I.53.40.7a–e,1,"Dior, House of"
+C.I.53.73,0,James Charles
+"C.I.54.16.1a, b",0,"Chanel, Gabrielle ""Coco"""
+"C.I.54.16.1a, b",1,"Chanel, House of"
+C.I.57.17.3,0,Weeks
+"C.I.58.13.6a, b",0,"Balenciaga, Cristobal"
+"C.I.58.13.6a, b",1,Balenciaga House of
+C.I.58.25a–c,0,"Adrian, Gilbert"
+C.I.58.34.30,0,"Dior, Christian"
+C.I.58.34.30,1,"Dior, House of"
+"C.I.58.49.4a, b",0,McCardell Claire
+"C.I.58.49.4a, b",1,Townley
+"C.I.60.21.1a, b",0,"Dior, Christian"
+"C.I.60.21.1a, b",1,"Dior, House of"
+C.I.61.40.4,0,"Poiret, Paul"
+C.I.66.14.2,0,"Garthwaite, Anna Maria"
+C.I.66.14.2,1,Lekeux Peter
+C.I.68.53.5a–h,0,Rossberg Herman
+C.I.69.23,0,Saint Laurent Yves
+C.I.69.23,1,"Saint Laurent Yves, Paris"
+C.I.X.56.2.1,0,Paquin House of
+C.I.X.56.2.1,1,Paquin Jeanne
+DA447.G7 H26 1876,0,"Hamilton, Anthony, Count"
+DA447.G7 H26 1876,1,"Chauvet, Jules Adolphe"
+DA447.G7 H26 1876,2,"Lamire, Leon"
+DA447.G7 H26 1876,3,Marius Michel et fils
+DC122.8 .P413 1785,0,"Le Moine, L. H."
+DC122.8 .P413 1785,1,de Perefixe Hardouin
+DC130.L14 L14 1749,0,"Auguste, Charles, marquis de La Fare"
+DC611.N846 A5 1788,0,La Veuve Besongne & Fils
+DH188.H67 W47 1568,0,"Wesenbeke, Jacques de"
+F595 .R38 1895,0,Harper & Brothers
+F595 .R38 1895,1,"Remington, Frederic"
+G150 .A45 1820,0,Marcilly
+GB1321 .M68 1766,0,"Moura Portugal, Bento de"
+GT2050 .U813 1884,0,"Avril, Paul"
+GT2050 .U813 1884,1,"Nimmo, J. C. and Bain"
+GT2050 .U813 1884,2,"Uzanne, Octave"
+GV1801 .L6 1889,0,Le Roux Hugues
+GV1801 .L6 1889,1,"Garnier, Jules"
+GV1801 .L6 1889,2,"Plon E., Nourrit et Cie."
+KKL273.1.Z94 C4 1815,0,"Lodigiani, Luigi"
+"L.2009.22.279a, b",0,"Ohr, George E."
+M2149.5 .C5 1768,0,Catholic Church
+M2149.5 .C5 1768,1,Baudouin
+N6659.P32 A4 1976,0,Galeria Arte Global
+N6659.P32 A4 1976,1,"Pape, Lygia"
+N6659.P32 A4 1976,2,"Oiticica, Hélio"
+N7433.4.B76 P43 1966,0,"Broodthaers, Marcel"
+N7433.4.C65 D43 2015,0,Black Stone Press
+N7433.4.C65 D43 2015,1,Heavenly Monkey
+N7433.4.C65 D43 2015,2,"Cohen, Claudia"
+N7433.4.C65 D43 2015,3,"Hodgson, Barbara"
+NC765 .A9 1683 Q,0,"Audran, Girard"
+ND3365.G7 B74 2009a Q,0,"Brotto, Carlo Bertoncello"
+ND3365.G7 B74 2009a Q,1,"Malato, Enrico"
+ND3365.G7 B74 2009a Q,2,Biblioteca Nazionale Marciana
+ND3365.G7 B74 2009a Q,3,Salerno Editrice
+ND616 .G35 1812,0,"Landon, Charles-Paul"
+ND616 .G35 1812,1,Chaignieau
+ND616 .G35 1812,2,Simier
+NE2049.5.W38 W38 1710,0,"Watteau, Antoine"
+NE2049.5.W38 W38 1710,1,"Cochin, Charles Nicolas, I"
+NE2049.5.W38 W38 1710,2,"Desplaces, Louis"
+NE2049.5.W38 W38 1710,3,"Thomassin, Henri Simon"
+NE2049.5.W38 W38 1710,4,Hardy-Mennil
+NK1483 .J7 1867 Q,0,"Gilbert, S. & T."
+NK1483 .J7 1867 Q,1,"Jones, Owen"
+NK1510 .J7 1868 Q,0,"Jones, Owen"
+NK1510 .J7 1868 Q,1,"Westwood, J. O."
+NK1510 .J7 1868 Q,2,"Wyatt, Matthew Digby Sir"
+NK1510 .J7 1868 Q,3,Bernard Quaritch Ltd.
+NK1510 .J7 1868 Q,4,"Waring, J. B."
+NK1530 .A5 1930,0,"Washburn, Ives"
+NK1530 .A5 1930,1,Glassgold A. C.
+NK1530 .A5 1930,2,"Leonard, Robert"
+NK1530 .A5 1930,3,American Union of Decorative Artists and Craftsmen
+NK1700 .I57 Q v.1 1900,0,"Schroll, A."
+NK1700 .I57 Q v.1 1900,1,"Abels, Ludwig"
+NK1700 .I57 Q v.2 1901,0,"Schroll, A."
+NK1700 .I57 Q v.2 1901,1,"Abels, Ludwig"
+NK2229 .S54 1793,0,"Sheraton, Thomas"
+NK2229 .S54 1793,1,"Bensley, Thomas"
+NK7983.A1 W36 1752,0,"Wang, Fu"
+NX511.A88 A88 1971 Quarto,0,"Andrews, Benny"
+NX511.A88 A88 1971 Quarto,1,"Baranik, Rudolf"
+NX511.A88 A88 1971 Quarto,2,Black Emergency Cultural Coalition and Artists and Writers Protest Against the War in Vietnam
+PA4375.M8 D3 1772,0,Plutarch
+PA4375.M8 D3 1772,1,L'Imprimerie Royale
+PA4375.M8 D3 1772,2,"La Porte du Theil, François Jean Gabriel de"
+PA6525.H4 N3 1762,0,Ovid
+PA6525.H4 N3 1762,1,"Gregori, Carlo"
+PA6525.H4 N3 1762,2,Durand
+PA6525.H4 N3 1762,3,"Conti, Giovan Stefano"
+PA6525.H4 N3 1762,4,"Nannini, Remigio"
+PA6555 .A2 1585,0,"Pithou, Pierre"
+PA6555 .A2 1585,1,Sulpicia
+PA6555 .A2 1585,2,Persius
+PA6555 .A2 1585,3,"Estienne, Robert"
+PA6555 .A2 1585,4,"Patisson, Mamert"
+PA6555 .A2 1585,5,"Juvenal, Decimus Junius"
+PA6558 .A5 1726,0,"Lavaur, M. (Guillaume de)"
+PA6558 .A5 1726,1,Petronius Arbiter
+PL2693.H76 H74 1977 Quarto,0,"Wang, Shifu"
+PL2693.H76 H74 1977 Quarto,1,Min Qiji
+PL2693.H76 H74 1977 Quarto,2,"Dittrich, Edith"
+PN1489 .M37 1651,0,"Martin, Docteur (Louis)"
+PN1489 .M37 1651,1,"Belleau, Remy"
+PN1489 .M37 1651,2,"Joly, Robert "
+PN1489 .M37 1651,3,"Moynet, Simon"
+PN1489 .M37 1651,4,"Folengo, Theophilo"
+PN6231.P6 B63 1669,0,"Blaeu, Johannes"
+PN6231.P6 B63 1669,1,"Briani, Girolamo"
+PN6231.P6 B63 1669,2,Simier
+PN6231.P6 B63 1669,3,"Boccalini, Traiano"
+PQ1189 .M66 1765,0,Barbou
+PQ1189 .M66 1765,1,"Monnet, Jean"
+PQ1189 .M66 1765,2,"de Querlon, Anne Gabriel Meusnier"
+PQ1795 .T5 1790,0,"Fénelon, François de Salignac de La Mothe-"
+PQ1795 .T5 1790,1,"Cochin, Charles Nicolas, II"
+PQ1795 .T5 1790,2,"Moreau, Jean Michel, the Younger"
+PQ1795 .T5 1790,3,"Bozerian, Jean Claude"
+PQ1809 .A1 1795,0,"Boileau Despréaux, Nicolas"
+PQ1809 .A1 1795,1,"La Fontaine, Jean de"
+PQ1809 .A1 1795,2,"Eisen, Charles Dominique Joseph"
+PQ1809 .A1 1795,3,"Didot, Pierre l'ainé"
+PQ1821 1773,0,"Bret, M. (Antoine)"
+PQ1821 1773,1,"Lambert, Michel"
+PQ1821 1773,2,"Molière, Jean-Baptiste Poquelin"
+PQ1821 1773,3,Voltaire
+PQ1821 1773,4,"Mignard, Pierre"
+PQ1821 1773,5,"Moreau, Jean Michel, the Younger"
+PQ1821 1773,6,Compagnie des libraires associés
+PQ1954.A54 L4 1741,0,"Argens, Jean-Baptiste de Boyer, marquis d'"
+PQ1954.A54 L4 1741,1,Pierre Paupie
+PQ2067.T28 D4 1770,0,"Thiroux d'Arconville, Marie Geneviève Charlotte Darlus"
+PQ2067.T28 D4 1770,1,"Diderot, Denis"
+PQ2067.T28 D4 1770,2,Compagnie des libraires associés
+PQ4272.F5 A34 1697,0,Kleihnans
+PQ4272.F5 A34 1697,1,"Gallet, George"
+PQ4272.F5 A34 1697,2,"Boccaccio, Giovanni"
+PQ4272.F5 A34 1697,3,"Hooghe, Romeyn de"
+PQ4567 .A2 1584,0,"Lavezzola, Alberto"
+PQ4567 .A2 1584,1,"Garofolo, Girolamo"
+PQ4567 .A2 1584,2,"Bononome, Giuseppe"
+PQ4567 .A2 1584,3,"Groto, Luigi"
+PQ4567 .A2 1584,4,"Eugenico, Niccolò"
+PQ4567 .A2 1584,5,"Ariosto, Ludovico"
+PQ4567 .A2 1584,6,"Pigna, Giovanni Battista"
+PQ4567 .A2 1584,7,"Rota, Giovanni"
+PQ4567 .A2 1584,8,"Camilli, Camillo"
+PQ4567 .A2 1584,9,"Ruscelli, Girolamo (Alessio Piemontese)"
+PQ4567 .A2 1584,10,Franceschi Francesco de'
+PQ4567 .A2 1584,11,"Porro, Girolamo"
+PS2267 .A1 1891,0,Houghton Mifflin Company
+PS2267 .A1 1891,1,"Remington, Frederic"
+PS2267 .A1 1891,2,"Longfellow, Henry Wadsworth"
+PS3519.O2625 G6 1927,0,"Douglas, Aaron"
+PS3519.O2625 G6 1927,1,"Johnson, James Weldon"
+PS3519.O2625 G6 1927,2,Viking Press
+PS3519.O2625 G6 1927,3,"Falls, Charles B."
+QB7 .C15 1772,0,Pierre de Goesin
+SB472.32.E54 W48 1771,0,"Latapie, François de Paule"
+SB472.32.E54 W48 1771,1,"Whately, Thomas"
+SB472.32.E54 W48 1771,2,"Jombert, Charles Antoine"
+TA71 .F73 1829,0,Ministère de l'intérieur
+TA71 .F73 1829,1,L'Imprimerie Royale
+TL620.A1 A6 1784,0,Chez Jubert
+TL620.A1 A6 1784a,0,Chez Desnos
+TS1484 .B56 1777,0,"Bernieres, de"
+TS1484 .B56 1777,1,Clousier
+U101 .M7814 1760,0,"Montecuccoli, Raimondo, Prince"
+U565 .S68 1740,0,"Sparre, Baron de"
+U565 .S68 1740,1,Padeloup
+U820.A9 S34 1603 F,0,"Schrenck von Nozing, Jacob"
+U820.A9 S34 1603 F,1,"Noyse von Campenhouten, Johann Engelbert"
+U820.A9 S34 1603 F,2,"Baur, Daniel"
+U820.A9 S34 1603 F,3,"Custos, Dominicus"
+U820.A9 S34 1603 F,4,"Fontana, Giovanni Battista"
+UD S83 1842 v.1,0,Stephens John Lloyd
+UD S83 1843 v.2,0,Stephens John Lloyd

--- a/scripts/output/met_artwork/met_artwork-artwork_artists-split.csv
+++ b/scripts/output/met_artwork/met_artwork-artwork_artists-split.csv
@@ -1,58 +1,58 @@
 Object Number,variable,artist
-02.7.1,0,"Ingham, Charles Cromwell"
-04.29.2,0,"Cole, Thomas"
-04.3.36,0,"von Winterthur, Heinrich Heid"
-06.1051.2,0,"Altdorfer, Albrecht"
-06.1335.1a–d,0,"Tencalla, Carpoforo Mazzetti"
-06.1335.1a–d,1,"Stazio, Abbondio"
-06.968.2,0,"Stimmer, Tobias"
-06.968.2,1,"Murer, Christoph"
-06.968.2,2,Pfau David II
-06.968.2,3,Pfau Hans Heinrich III
+02.7.1,0,Charles Cromwell Ingham
+04.29.2,0,Thomas Cole
+04.3.36,0,Heinrich Heid von Winterthur
+06.1051.2,0,Albrecht Altdorfer
+06.1335.1a–d,0,Carpoforo Mazzetti Tencalla
+06.1335.1a–d,1,Abbondio Stazio
+06.968.2,0,Tobias Stimmer
+06.968.2,1,Christoph Murer
+06.968.2,2,David II Pfau
+06.968.2,3,Hans Heinrich III Pfau
 "07.286.36a, b",0,Penthesilea Painter
 07.286.84,0,Painter of the Woolly Satyrs
-08.162.1,0,"Rossetti, Dante Gabriel"
-08.162.1,1,"Dunn, Henry Treffry"
-08.183.1,0,"Bellini, Giovanni"
-10.125.685,0,"Dennis, Thomas"
-10.125.685,1,"Searle, William"
-10.125.83,0,"Townsend, John"
-10.189,0,"Veronese, Paolo (Paolo Caliari)"
-10.228.1,0,"Homer, Winslow"
-10.64.5,0,"Homer, Winslow"
-100.1 B59,0,"Blanc, Charles"
-100.1 B59,1,"Humbert, de Superville David-Pierre Giottino"
-100.1 B591,0,"Gaucherel, Léon"
-100.1 B591,1,"Blanc, Charles"
+08.162.1,0,Dante Gabriel Rossetti
+08.162.1,1,Henry Treffry Dunn
+08.183.1,0,Giovanni Bellini
+10.125.685,0,Thomas Dennis
+10.125.685,1,William Searle
+10.125.83,0,John Townsend
+10.189,0,Paolo Veronese (Paolo Caliari)
+10.228.1,0,Winslow Homer
+10.64.5,0,Winslow Homer
+100.1 B59,0,Charles Blanc
+100.1 B59,1,David-Pierre Giottino Humbert de Superville
+100.1 B591,0,Léon Gaucherel
+100.1 B591,1,Charles Blanc
 100.51 B61 no.2,0,Man Ray
-100.51 B61 no.2,1,"Duchamp, Marcel"
-100.51 B61 no.2,2,"Roché, H. P."
-106.1 V28 F,0,Barrie
-106.1 V28 F,1,"Strahan, Edward"
-107.1 K75 1920 no.8,0,"Bakst, Léon"
-107.1 K75 1920 no.8,1,"Knoedler, M., & Co."
+100.51 B61 no.2,1,Marcel Duchamp
+100.51 B61 no.2,2,H. P. Roché
+106.1 V28 F,0,George Barrie
+106.1 V28 F,1,Edward Strahan (Earl Shinn)
+107.1 K75 1920 no.8,0,Léon Bakst
+107.1 K75 1920 no.8,1,M. Knoedler & Co.
 107.15 R474 no.7,0,Museu de Arte Moderna
-109A L83,0,"Lomazzo, Giovanni Paolo"
-11.116.4,0,"Inness, George"
-11.118,0,"Carpaccio, Vittore"
+109A L83,0,Giovanni Paolo Lomazzo
+11.116.4,0,George Inness
+11.118,0,Vittore Carpaccio
 11.126.1,0,Giotto di Bondone
-11.156,0,"Durand, Asher Brown"
-11.173.1,0,"Rodin, Auguste"
-110.5B75 C44,0,"Chizzola, Luigi"
-12.11.1,0,"Rodin, Auguste"
+11.156,0,Asher Brown Durand
+11.173.1,0,Auguste Rodin
+110.5B75 C44,0,Luigi Chizzola
+12.11.1,0,Auguste Rodin
 12.3.1,0,Master Potter A
-120 Se6,0,"Serlio, Sebastiano"
-120.32P17 P17,0,"Palladio, Andrea"
-123.1 F412,0,"Washburn, Ives"
-123.1 F412,1,"Ferriss, Hugh"
-125.97 D932,0,"Dürer, Albrecht"
-126.5V55 B292 Q v.3,0,"Boito, Camillo"
-126.5V55 B292 Q v.3,1,"Ongania, Ferdinando"
-126.6 R61,0,"Colin et Cie., Éditeurs"
-126.6 R61,1,"Rodin, Auguste"
-126.6 R61,2,"Morice, Charles"
-13.160.10,0,Al-Sufi `Abd al-Rahman
-13.2,0,"Whistler, James McNeill"
+120 Se6,0,Sebastiano Serlio
+120.32P17 P17,0,Andrea Palladio
+123.1 F412,0,Ives Washburn
+123.1 F412,1,Hugh Ferriss
+125.97 D932,0,Albrecht Dürer
+126.5V55 B292 Q v.3,0,Camillo Boito
+126.5V55 B292 Q v.3,1,Ferdinando Ongania
+126.6 R61,0,"Armand Colin et Cie., Éditeurs"
+126.6 R61,1,Auguste Rodin
+126.6 R61,2,Charles Morice
+13.160.10,0,`Abd al-Rahman al-Sufi
+13.2,0,James McNeill Whistler
 13.228.13.6,0,Maulana Azhar
 13.228.13.6,1,Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
 13.228.13.6,2,Unknown
@@ -67,119 +67,119 @@ Object Number,variable,artist
 13.228.33,1,Muhammad Husain Kashmiri
 13.228.33,2,Amir Khusrau Dihlavi
 13.228.7.5,0,Sultan Muhammad Nur
-13.228.7.5,1,Mahmud Muzahib
-13.228.7.5,2,Shaykh Zada
+13.228.7.5,1,Mahmud Muzahhib
+13.228.7.5,2,Shaikh Zada
 13.228.7.5,3,Nizami (Ilyas Abu Muhammad Nizam al-Din of Ganja)
-130.8 C23,0,"Carradori, Francesco"
-131.1M58 C75,0,"Condivi, Ascanio"
-139.3 N48 F,0,"Hayashi, Tadamasa"
+130.8 C23,0,Francesco Carradori
+131.1M58 C75,0,Ascanio Condivi
+139.3 N48 F,0,Tadamasa Hayashi
 139.3 N48 F,1,De Vinne Press
-139.3 N48 F,2,"Bishop, Heber R."
-139.3 N48 F,3,Kunz George Frederick
-139.3 N48 F,4,Bushell Stephen Wootton Dr.
-139.3 N48 F,5,"Lilley, Robert"
-14.100.172,0,"Iyetada, Saotome"
-14.100.172,1,"Munesuke, Myōchin"
-14.126.1,0,"Sully, Thomas"
+139.3 N48 F,2,Heber R. Bishop
+139.3 N48 F,3,George Frederick Kunz
+139.3 N48 F,4,Dr. Stephen Wootton Bushell
+139.3 N48 F,5,Robert Lilley
+14.100.172,0,Saotome Iyetada
+14.100.172,1,Myōchin Munesuke
+14.126.1,0,Thomas Sully
 14.130.12,0,Euphiletos Painter
 14.130.14,0,Hirschfeld Workshop
-14.25.1425,0,"Gemlich, Ambrosius"
-14.25.1425,1,"Peck, Peter"
-14.25.1623,0,"Schmidt, Jacob"
-14.26,0,"Coggeshall, Patty"
-14.40.602,0,"Hals, Frans"
-14.40.605,0,"Hals, Frans"
+14.25.1425,0,Ambrosius Gemlich
+14.25.1425,1,Peter Peck
+14.25.1623,0,Jacob Schmidt
+14.26,0,Patty Coggeshall
+14.40.602,0,Frans Hals
+14.40.605,0,Frans Hals
 14.40.618,0,Rembrandt (Rembrandt van Rijn)
-14.40.619,0,"Dyck, Anthony van"
-14.40.623,0,"Ruisdael, Jacob van"
-14.40.626–27,0,"Memling, Hans"
-14.40.633,0,"Dürer, Albrecht"
+14.40.619,0,Anthony van Dyck
+14.40.623,0,Jacob van Ruisdael
+14.40.626–27,0,Hans Memling
+14.40.633,0,Albrecht Dürer
 14.40.642,0,Botticelli (Alessandro di Mariano Filipepi)
-14.40.675,0,"Rossellino, Antonio"
+14.40.675,0,Antonio Rossellino
 14.40.687,0,Clodion (Claude Michel)
 14.40.689,0,Giambologna
-14.74.17,0,American Flint Glass Manufactory 
-14.74.17,1,"Stiegel, Henry William"
+14.74.17,0,American Flint Glass Manufactory
+14.74.17,1,Henry William Stiegel
 14.76.6,0,Unidentified Artist
-143.6 S92,0,"Froehner, Wilhelm"
-143.7W41 W413,0,"Wedgwood, Josiah"
-146.8  M821 Q,0,"Morgan, J. Pierpont"
-146.8  M821 Q,1,"Williamson, George Charles"
-146.9 T34,0,"Thiout, Antoine"
-15.113.1–.5; 29.158.885,0,"Holden, Richard"
-15.113.1–.5; 29.158.885,1,"Tachaux, Daniel"
-15.142.2,0,"Sargent, John Singer"
-15.30.59,0,"Durand, Asher Brown"
-15.30.61,0,"Kensett, John Frederick"
-15.30.62,0,"Gifford, Sanford Robinson"
-15.30.67,0,"Church, Frederic Edwin"
-15.75,0,"French, Daniel Chester"
-152.7 T36 Q,0,"Thomas, Auguste H."
-153 Ar7 F,0,Appleton & Co.
+143.6 S92,0,Wilhelm Froehner
+143.7W41 W413,0,Josiah Wedgwood
+146.8  M821 Q,0,J. Pierpont Morgan
+146.8  M821 Q,1,George Charles Williamson
+146.9 T34,0,Antoine Thiout l'aîné
+15.113.1–.5; 29.158.885,0,Richard Holden
+15.113.1–.5; 29.158.885,1,Daniel Tachaux
+15.142.2,0,John Singer Sargent
+15.30.59,0,Asher Brown Durand
+15.30.61,0,John Frederick Kensett
+15.30.62,0,Sanford Robinson Gifford
+15.30.67,0,Frederic Edwin Church
+15.75,0,Daniel Chester French
+152.7 T36 Q,0,Auguste H. Thomas
+153 Ar7 F,0,D. Appleton & Co.
 159.4 N486,0,"Plandome Press, Inc."
-159.4 N486,1,"Silve, David"
-159.4 N486,2,"Dwiggins, William Addison"
-159.4 N486,3,Metropolitan Museum of Art
-16.2.2,0,"Cassatt, Mary"
+159.4 N486,1,David Silve
+159.4 N486,2,William Addison Dwiggins
+159.4 N486,3,The Metropolitan Museum of Art
+16.2.2,0,Mary Cassatt
 16.30ab,0,Raphael (Raffaello Sanzio or Santi)
-16.53,0,"Sargent, John Singer"
-16.68.2,0,"Blackburn, Joseph"
-161 H41,0,"Taylor, I. & J."
-161 H41,1,"Hepplewhite, A. & Co."
-161 L841,0,"Brown, W. and O'Neil A."
+16.53,0,John Singer Sargent
+16.68.2,0,Joseph Blackburn
+161 H41,0,I. & J. Taylor
+161 H41,1,A. Hepplewhite & Co.
+161 L841,0,W. Brown and A. O'Neil
 161 L841,1,London Society of Cabinet Makers
-161.1 C44 Q,0,"Chippendale, Thomas"
-17.104,0,"Saint-Gaudens, Augustus"
+161.1 C44 Q,0,Thomas Chippendale
+17.104,0,Augustus Saint-Gaudens
 17.142.1,0,Leonardo da Vinci
-17.172,0,"Eakins, Thomas"
-17.190.1720,0,"Negroli, Filippo"
+17.172,0,Thomas Eakins
+17.190.1720,0,Filippo Negroli
 17.190.2045,0,Medici Porcelain Factory
-17.190.636,0,"Emmoser, Gerhard"
-17.190.724,0,Heinrich of Constance Master
-17.190.823,0,Walbaum Matthias
-17.190.823,1,"Mozart, Anton"
+17.190.636,0,Gerhard Emmoser
+17.190.724,0,Master Heinrich of Constance
+17.190.823,0,Matthias Walbaum
+17.190.823,1,Anton Mozart
 "17.230.14a, b",0,Exekias
-17.3.159,0,"Whistler, James McNeill"
-17.3.90,0,"Whistler, James McNeill"
-17.40.2a–r,0,Bousch Valentin
-17.50.17-36,0,"Castiglione, Giovanni Benedetto (Il Grechetto)"
-17.50.17-36,1,"Merwede, Matthuys van de, Lord of Clootwyck"
-17.50.17-36,2,"Rossi, Giovanni Giacomo De"
+17.3.159,0,James McNeill Whistler
+17.3.90,0,James McNeill Whistler
+17.40.2a–r,0,Valentin Bousch
+17.50.17-36,0,Giovanni Benedetto Castiglione (Il Grechetto)
+17.50.17-36,1,"Matthys van de Merwede, Lord of Clootwyck"
+17.50.17-36,2,Giovanni Giacomo De Rossi
 17.81.4,0,Bihzad
 17.81.4,1,Hafiz
-"17.87.3a, b",0,"Liger, C."
-17.90.1,0,"Saint-Gaudens, Augustus"
-17.97.5,0,"Whistler, James McNeill"
-170.1 AL1 Quarto,0,"Albers, Josef"
+"17.87.3a, b",0,C. Liger
+17.90.1,0,Augustus Saint-Gaudens
+17.97.5,0,James McNeill Whistler
+170.1 AL1 Quarto,0,Josef Albers
 170.1 AL1 Quarto,1,Yale University Press
-170.1 C424,0,"Chevreul, Michel Eugène"
-170.1 C424,1,"Martel, Charles"
-170.1 R674,0,"Rood, Ogden Nicholas"
-170.9 F46,0,"Fielding, Theodore Henry Adolphus"
-171.1 C17,0,"Carducho, Vincente"
-171.1 C17,1,"Martínez, Francisco"
-171.1 C17,2,"López, Francisco"
-171.1 C17,3,"Fernández, Francisco"
-175T49 R43,0,"Ridolfi, Carlo"
-18.70.28,0,"Pisano, Giovanni"
-19.115.2,0,"Muneakira, Myōchin"
-19.126,0,"MacNeil, Hermon Atkins"
+170.1 C424,0,Michel Eugène Chevreul
+170.1 C424,1,Charles Martel
+170.1 R674,0,Ogden Nicholas Rood
+170.9 F46,0,Theodore Henry Adolphus Fielding
+171.1 C17,0,Vicente Carducho
+171.1 C17,1,Francisco Martínez
+171.1 C17,2,Francisco López
+171.1 C17,3,Francisco Fernández
+175T49 R43,0,Carlo Ridolfi
+18.70.28,0,Giovanni Pisano
+19.115.2,0,Myōchin Muneakira
+19.126,0,Hermon Atkins MacNeil
 "19.131.1a–r, t–w, .2a–c; 27.183.16",0,Royal Workshops at Greenwich
-"19.131.1a–r, t–w, .2a–c; 27.183.16",1,"Holbein, Hans, the Younger"
-19.164,0,"Bruegel, Pieter, the Elder"
-19.51.7,0,"Degas, Edgar"
-19.51.7,1,"Manet, Édouard"
+"19.131.1a–r, t–w, .2a–c; 27.183.16",1,Hans Holbein the Younger
+19.164,0,Pieter Bruegel the Elder
+19.51.7,0,Edgar Degas
+19.51.7,1,Édouard Manet
 19.68.1,0,Muhammad ibn Badr al-Din Jajarmi
-19.73.1,0,"Dürer, Albrecht"
-19.74.1,0,"Raimondi, Marcantonio"
+19.73.1,0,Albrecht Dürer
+19.74.1,0,Marcantonio Raimondi
 19.74.1,1,Raphael (Raffaello Sanzio or Santi)
-19.77.2,0,"Ingres, Jean Auguste Dominique"
-192H221  B61,0,Blemly William Ignatius
-1950-04-01 00:00:00,0,"Penn, Irving"
-1970.137.1,0,Riemenschneider Tilman
-1970.179.1a–q,0,"Boutet, Nicholas-Noël"
+19.77.2,0,Jean Auguste Dominique Ingres
+192H221  B61,0,William Ignatius Blemly
+1950-04-01 00:00:00,0,Irving Penn
+1970.137.1,0,Tilman Riemenschneider
+1970.179.1a–q,0,Nicolas Noël Boutet
 1970.230.4,0,Vincennes Manufactory
-1970.230.4,1,"Duplessis, Jean-Claude"
+1970.230.4,1,Jean-Claude Duplessis
 1970.301.2,0,Sultan Muhammad
 1970.301.2,1,Abu'l Qasim Firdausi
 1970.301.3,0,Sultan Muhammad
@@ -187,1289 +187,1286 @@ Object Number,variable,artist
 1970.301.51,0,Qasim ibn 'Ali
 1970.301.51,1,Abu'l Qasim Firdausi
 1970.35.1,0,Pottier and Stymus Manufacturing Company
-1970.727.1,0,"Hine, Lewis"
-1970.77,0,"Schuech, Israel"
-1970.77,1,"Martinez, Juan"
-1970.89.1a–c,0,Ungaro Emanuel
-1971.155,0,"Carracci, Annibale"
-1971.158.1,0,Mosca Simone
-1971.219,0,"Roux, Alexander"
-1971.63.1,0,"Panini, Giovanni Paolo"
-1971.79.4,0,"Givenchy, Hubert de"
-1971.79.4,1,Givenchy House of
+1970.727.1,0,Lewis Hine
+1970.77,0,Israel Schuech
+1970.77,1,Juan Martinez
+1970.89.1a–c,0,Emanuel Ungaro
+1971.155,0,Annibale Carracci
+1971.158.1,0,Simone Mosca
+1971.219,0,Alexander Roux
+1971.63.1,0,Giovanni Paolo Panini
+1971.79.4,0,Hubert de Givenchy
+1971.79.4,1,House of Givenchy
 1971.86,0,Velázquez (Diego Rodríguez de Silva y Velázquez)
-1972.111.1a-c,0,Mannello Angelo
-1972.118.210,0,"Delacroix, Eugène"
-1972.127,0,"Smith, David"
-1972.223,0,"Le Bourgeois, Pierre"
-1972.223,1,"Le Bourgeois, Marin"
-1972.263.6,0,"Davis, Joseph H."
+1972.111.1a-c,0,Angelo Mannello
+1972.118.210,0,Eugène Delacroix
+1972.127,0,David Smith
+1972.223,0,Pierre Le Bourgeois
+1972.223,1,Marin Le Bourgeois
+1972.263.6,0,Joseph H. Davis
 1972.47,0,Herter Brothers
-1972.60.1,0,"Wright, Frank Lloyd"
-"1973.104.2a, b",0,"Grès, Madame"
-1973.120.1,0,QU DING
-1973.120.6,0,QIAN XUAN
-1973.257,0,"Ward, John Quincy Adams"
-1973.282.2,0,Ferragamo Salvatore
-1973.315.1,0,Joubert Gilles
+1972.60.1,0,Frank Lloyd Wright
+"1973.104.2a, b",0,Madame Grès (Alix Barton)
+1973.120.1,0,Qu Ding
+1973.120.6,0,Qian Xuan
+1973.257,0,John Quincy Adams Ward
+1973.282.2,0,Salvatore Ferragamo
+1973.315.1,0,Gilles Joubert
 1973.634,0,Canaletto (Giovanni Antonio Canal)
 "1973.6a, b",0,Louiseboulanger
-1974.136.3,0,"Courrèges, André"
-1974.185.3a–c,0,Harris H.
-1974.185.3a–c,1,Scholte
+1974.136.3,0,André Courrèges
+1974.185.3a–c,0,H. Harris
+1974.185.3a–c,1,F. Scholte
 "1974.214.26a, b",0,Gorham Manufacturing Company
 "1974.214.26a, b",1,Spaulding and Company
-1974.356.120a,0,"Bauer, Johann Michael"
-1974.356.524,0,"Bustelli, Franz Anton"
+1974.356.120a,0,Johann Michael Bauer
+1974.356.524,0,Franz Anton Bustelli
 1974.356.524,1,Nymphenburg Porcelain Manufactory
-1975.1.1015,0,Vasaro Giovanni Maria
+1975.1.1015,0,workshop of Giovanni Maria Vasaro
 1975.1.1019,0,Nicola da Urbino
-1975.1.103,0,"Baronzio, Giovanni"
+1975.1.103,0,Giovanni Baronzio
 1975.1.104,0,Master of Saint Francis
-1975.1.110,0,"Christus, Petrus"
-1975.1.1103,0,"Andreoli, Giorgio Maestro"
-1975.1.113,0,"Memling, Hans"
-1975.1.119,0,"David, Gerard"
+1975.1.110,0,Petrus Christus
+1975.1.1103,0,Maestro Giorgio Andreoli
+1975.1.113,0,Hans Memling
+1975.1.119,0,Gerard David
 1975.1.1194,0,Italian
 1975.1.1194,1,French
-1975.1.12,0,"Martini, Simone"
-1975.1.120,0,"David, Gerard"
-1975.1.1232,0,Master IC
-1975.1.1232,1,"Cour, Jean"
-1975.1.1244,0,"Goullons, Jacques"
-1975.1.130,0,"Hey, Jean (called Master of Moulins)"
-1975.1.138,0,"Holbein, Hans, the Younger"
+1975.1.12,0,Simone Martini
+1975.1.120,0,Gerard David
+1975.1.1232,0,Master IC (probably Jean Court)
+1975.1.1232,1,Jean Cour (or Court)
+1975.1.1244,0,Jacques Goullons
+1975.1.130,0,Jean Hey (called Master of Moulins)
+1975.1.138,0,Hans Holbein the Younger
 1975.1.140,0,Rembrandt (Rembrandt van Rijn)
-1975.1.141,0,"Borch, Gerard ter, the Younger"
-1975.1.142,0,"Borch, Gerard ter, the Younger"
-1975.1.144,0,"Hooch, Pieter de"
-1975.1.145,0,"Greco, El (Domenikos Theotokopoulos)"
-1975.1.146,0,"Greco, El (Domenikos Theotokopoulos)"
+1975.1.141,0,Gerard ter Borch the Younger
+1975.1.142,0,Gerard ter Borch the Younger
+1975.1.144,0,Pieter de Hooch
+1975.1.145,0,El Greco (Domenikos Theotokopoulos)
+1975.1.146,0,El Greco (Domenikos Theotokopoulos)
 1975.1.148,0,Goya (Francisco de Goya y Lucientes)
 1975.1.155,0,Balthus (Balthasar Klossowski)
-1975.1.1558,0,"Vasters, Reinhold"
+1975.1.1558,0,Reinhold Vasters
 1975.1.1558,1,Italian
-1975.1.156,0,"Bonnard, Pierre"
-1975.1.159,0,"Braque, Georges"
+1975.1.156,0,Pierre Bonnard
+1975.1.159,0,Georges Braque
 1975.1.16,0,Bartolo di Fredi
-1975.1.160,0,"Cézanne, Paul"
-1975.1.162,0,"Corot, Camille"
+1975.1.160,0,Paul Cézanne
+1975.1.162,0,Camille Corot
 1975.1.1638,0,del Tasso
-1975.1.168,0,"Derain, André"
-1975.1.186,0,"Ingres, Jean Auguste Dominique"
-1975.1.1915,0,"Orley, Bernard van"
-1975.1.1915,1,"Pannemaker, Pieter de"
-1975.1.192,0,"Marquet, Albert"
-1975.1.194,0,"Matisse, Henri"
-1975.1.196,0,"Monet, Claude"
-1975.1.199,0,"Renoir, Auguste"
-1975.1.201,0,"Renoir, Auguste"
-1975.1.2026,0,"Carlin, Martin"
+1975.1.168,0,André Derain
+1975.1.186,0,Jean Auguste Dominique Ingres
+1975.1.1915,0,Bernard van Orley
+1975.1.1915,1,Pieter de Pannemaker
+1975.1.192,0,Albert Marquet
+1975.1.194,0,Henri Matisse
+1975.1.196,0,Claude Monet
+1975.1.199,0,Auguste Renoir
+1975.1.201,0,Auguste Renoir
+1975.1.2026,0,Martin Carlin
 1975.1.2026,1,Sèvres Manufactory
 1975.1.2026,2,French
-1975.1.209,0,"Signac, Paul"
+1975.1.209,0,Paul Signac
 1975.1.21,0,Niccolò di Buonaccorso
 1975.1.2101,0,"Italian, Siena"
-1975.1.225,0,"Vuillard, Édouard"
-1975.1.231,0,"Gogh, Vincent van"
-1975.1.2486,0,"David, Gerard"
-1975.1.2487,0,"Bening, Simon"
-1975.1.2490,0,"Fouquet, Jean"
-1975.1.2491,0,"Marmitta, Francesco"
+1975.1.225,0,Édouard Vuillard
+1975.1.231,0,Vincent van Gogh
+1975.1.2486,0,Gerard David
+1975.1.2487,0,Simon Bening
+1975.1.2490,0,Jean Fouquet
+1975.1.2491,0,Francesco di Marco Marmitta da Parma
 1975.1.27,0,Osservanza Master
-1975.1.270,0,"Bartolomeo, Fra (Bartolomeo di Paolo del Fattorino)"
+1975.1.270,0,Fra Bartolomeo (Bartolomeo di Paolo del Fattorino)
 1975.1.297,0,Canaletto (Giovanni Antonio Canal)
 1975.1.31,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
 1975.1.335,0,Lorenzo Monaco (Piero di Giovanni)
-1975.1.342,0,"Guardi, Francesco"
+1975.1.342,0,Francesco Guardi
 1975.1.369,0,Leonardo da Vinci
 1975.1.37,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
 1975.1.376,0,Francesco di Giorgio Martini
 1975.1.38,0,Giovanni di Paolo (Giovanni di Paolo di Grazia)
-1975.1.410,0,"Pollaiuolo, Antonio"
-1975.1.443,0,"Tiepolo, Giovanni Battista"
-1975.1.473,0,"Tiepolo, Giovanni Domenico"
-1975.1.514,0,"Tiepolo, Giovanni Domenico"
+1975.1.410,0,Antonio Pollaiuolo
+1975.1.443,0,Giovanni Battista Tiepolo
+1975.1.473,0,Giovanni Domenico Tiepolo
+1975.1.514,0,Giovanni Domenico Tiepolo
 1975.1.54,0,Benvenuto di Giovanni
-1975.1.553,0,"Zuccaro, Taddeo"
-1975.1.58,0,"Daddi, Bernardo"
-1975.1.592,0,"Cross, Henri-Edmond"
-1975.1.647,0,"Ingres, Jean Auguste Dominique"
+1975.1.553,0,Taddeo Zuccaro
+1975.1.58,0,Bernardo Daddi
+1975.1.592,0,Henri-Edmond Cross (Henri-Edmond Delacroix)
+1975.1.647,0,Jean Auguste Dominique Ingres
 1975.1.66,0,Lorenzo Monaco (Piero di Giovanni)
 1975.1.661,0,Claude Lorrain (Claude Gellée)
-1975.1.669,0,"Matisse, Henri"
+1975.1.669,0,Henri Matisse
 1975.1.7,0,Ugolino da Siena (Ugolino di Nerio)
-1975.1.704,0,"Seurat, Georges"
-1975.1.710,0,"Signac, Paul"
-1975.1.731,0,"Toulouse-Lautrec, Henri de"
-1975.1.736,0,"Vallotton, Félix"
+1975.1.704,0,Georges Seurat
+1975.1.710,0,Paul Signac
+1975.1.731,0,Henri de Toulouse-Lautrec
+1975.1.736,0,Félix Vallotton
 1975.1.74,0,Botticelli (Alessandro di Mariano Filipepi)
-1975.1.753,0,"Villon, Jacques"
-1975.1.763,0,"Watteau, Antoine"
-1975.1.774,0,"Gogh, Vincent van"
+1975.1.753,0,Jacques Villon
+1975.1.763,0,Antoine Watteau
+1975.1.774,0,Vincent van Gogh
 1975.1.792,0,Rembrandt (Rembrandt van Rijn)
 1975.1.794,0,Rembrandt (Rembrandt van Rijn)
 1975.1.799,0,Rembrandt (Rembrandt van Rijn)
-1975.1.843,0,"Rubens, Peter Paul"
-1975.1.848,0,"van der Stockt, Vranke"
+1975.1.843,0,Peter Paul Rubens
+1975.1.848,0,Vranke van der Stockt
 1975.1.85,0,Jacometto (Jacometto Veneziano)
-1975.1.855,0,"Baldung, Hans (called Hans Baldung Grien)"
-1975.1.859,0,"Dürer, Albrecht"
+1975.1.855,0,Hans Baldung (called Hans Baldung Grien)
+1975.1.859,0,Albrecht Dürer
 1975.1.86,0,Jacometto (Jacometto Veneziano)
-1975.1.872,0,"Schongauer, Martin"
-1975.1.940,0,"Prendergast, Maurice Brazil"
+1975.1.872,0,Martin Schongauer
+1975.1.940,0,Maurice Brazil Prendergast
 1975.1.95,0,Maestro delle Storie del Pane
 1975.1.96,0,Maestro delle Storie del Pane
-1975.15a–c,0,"Doucet, Jacques"
-1975.16,0,"Heade, Martin Johnson"
-1975.246.5a–c,0,James Charles
+1975.15a–c,0,Jacques Doucet
+1975.16,0,Martin Johnson Heade
+1975.246.5a–c,0,Charles James
 1975.268.48a–d,0,Kano Sansetsu
-1975.27.1,0,"Edmonds, Francis William"
-1975.319.1,0,"Cassatt, Mary"
-1975.321,0,"Weber, Max"
-1975.59,0,Koyate Mamadou
-1976.124.7a–c,0,"Balenciaga, Cristobal"
-1976.124.7a–c,1,Balenciaga House of
-1976.155.110,0,"Carlin, Martin"
-1976.155.110,1,"Bouillat père, Edme François"
+1975.27.1,0,Francis William Edmonds
+1975.319.1,0,Mary Cassatt
+1975.321,0,Max Weber
+1975.59,0,Mamadou Koyate (bridge by Djimo Koyate)
+1976.124.7a–c,0,Cristobal Balenciaga
+1976.124.7a–c,1,House of Balenciaga
+1976.155.110,0,Martin Carlin
+1976.155.110,1,Edme François Bouillat père
 1976.155.110,2,Sèvres Manufactory
-1976.324,0,"Barry, and Son Joseph B."
-1976.332,0,"Trumbull, John"
-"1976.368.5a, b",0,"Blass, Bill"
+1976.324,0,Joseph B. Barry and Son
+1976.332,0,John Trumbull
+"1976.368.5a, b",0,Bill Blass
 "1976.368.5a, b",1,PBM
 "1976.368.5a, b",2,Bonwit Teller & Co.
-1976.414.3a-ggg,0,"Dupas, Jean"
-1976.414.3a-ggg,1,"Champigneulle, Jacques-Charles"
-1976.646,0,"Le Gray, Gustave"
-1976.652.3-4,0,"Edouart, Auguste"
-1976.92,0,"Bernini, Gian Lorenzo"
-1976.92,1,"Bernini, Pietro"
-1977.1,0,"David, Jacques Louis"
-1977.1.11,0,"Heiglen, Johann Erhard"
-1977.1.3,0,"Tiepolo, Giovanni Battista"
-1977.243,0,"Stuart, Gilbert"
+1976.414.3a-ggg,0,Jean Dupas
+1976.414.3a-ggg,1,Jacques-Charles Champigneulle
+1976.646,0,Gustave Le Gray
+1976.652.3-4,0,Auguste Edouart
+1976.92,0,Gian Lorenzo Bernini
+1976.92,1,Pietro Bernini
+1977.1,0,Jacques Louis David
+1977.1.11,0,Johann Erhard Heiglen
+1977.1.3,0,Giovanni Battista Tiepolo
+1977.243,0,Gilbert Stuart
 "1977.329.5a, b",0,Rébè
-"1977.329.5a, b",1,Saint Laurent Yves
-"1977.329.5a, b",2,"Dior, House of"
-1977.78,0,HAN GAN
-1978.163.2a–c,0,Kamali Norma
-1978.203,0,"Lane, Fitz Henry"
-1978.288.23a–f,0,Schiaparelli Elsa
+"1977.329.5a, b",1,Yves Saint Laurent
+"1977.329.5a, b",2,House of Dior
+1977.78,0,Han Gan
+1978.163.2a–c,0,Norma Kamali
+1978.203,0,Fitz Henry Lane (formerly Fitz Hugh Lane)
+1978.288.23a–f,0,Elsa Schiaparelli
 1978.288.23a–f,1,Bonwit Teller & Co.
 "1978.288.7a, b",0,Callot Soeurs
 1978.412.499,0,Zlan of Belewale
-1978.61.1-.6,0,"Bearden, Romare"
+1978.61.1-.6,0,Romare Bearden
 1979.206.1047,0,Chakalte'
-1979.29,0,Buli Master
-1979.32,0,"Esherick, Wharton"
-"1979.380a, b",0,Martin Christian Frederick
-1979.394,0,"Ward, John Quincy Adams"
-1979.395,0,"Earl, Ralph"
-1979.396.1,0,"Vermeer, Johannes"
-"1979.435.10a, b",0,"Givenchy, Hubert de"
-"1979.435.10a, b",1,Givenchy House of
+1979.29,0,"Buli Master, possibly Ngongo ya Chintu (Hemba, ca. 1810-1870)"
+1979.32,0,Wharton Esherick
+"1979.380a, b",0,Christian Frederick Martin
+1979.394,0,John Quincy Adams Ward
+1979.395,0,Ralph Earl
+1979.396.1,0,Johannes Vermeer
+"1979.435.10a, b",0,Hubert de Givenchy
+"1979.435.10a, b",1,House of Givenchy
 1979.5a–d,0,Wang Hui
-1979.622,0,"Watkins, Carleton E."
+1979.622,0,Carleton E. Watkins
 1980.1023.5,0,Brassaï
-"1980.111a,b",0,Grenser H.
-1980.351,0,"Mies van der Rohe, Ludwig"
-1980.42,0,"Lichtenstein, Roy"
-1980.92.1a–c,0,Drecoll
-1981.238,0,"Rubens, Peter Paul"
+"1980.111a,b",0,H. Grenser
+1980.351,0,Ludwig Mies van der Rohe
+1980.42,0,Roy Lichtenstein
+1980.92.1a–c,0,Drécoll
+1981.238,0,Peter Paul Rubens
 1981.276,0,Guo Xi
-1981.278,0,Huizong Emperor
-1981.35,0,"O'Keeffe, Georgia"
+1981.278,0,Emperor Huizong
+1981.35,0,Georgia O'Keeffe
 1981.380.2,0,Callot Soeurs
-1981.4.1a–o,0,GONG XIAN
-"1981.57.2a, b",0,LEINBERGER HANS
-1982.147.25,0,"Pollock, Jackson"
-1982.16.3,0,"De Kooning, Willem"
-1982.171.1,0,"Kim, Kwang Ju"
-1982.179.29,0,"Derain, André"
+1981.4.1a–o,0,Gong Xian
+"1981.57.2a, b",0,Hans Leinberger
+1982.147.25,0,Jackson Pollock
+1982.16.3,0,Willem de Kooning
+1982.171.1,0,Kim Kwang Ju
+1982.179.29,0,André Derain
 1982.213,0,Kamal Muhammad
-1982.213,1,Muhammad Chand
-1982.30ab,0,"Frankl, Paul T."
-1982.324,0,"Meares, Richard"
-1982.443.2,0,"Powers, Hiram"
-1982.45,0,"Briosco, Andrea, called Riccio"
-"1982.4a, b",0,"Fletcher, Thomas"
-"1982.4a, b",1,"Gardiner, Sidney"
+1982.213,1,Chand Muhammad
+1982.30ab,0,Paul T. Frankl
+1982.324,0,Richard Meares
+1982.443.2,0,Hiram Powers
+1982.45,0,"Andrea Briosco, called Riccio"
+"1982.4a, b",0,Thomas Fletcher
+"1982.4a, b",1,Sidney Gardiner
 1982.53,0,Balthus (Balthasar Klossowski)
-1982.55.1,0,"Pippin, Horace"
-1982.59.1–.105,0,"Appleton, Thomas"
+1982.55.1,0,Horace Pippin
+1982.59.1–.105,0,Thomas Appleton
 1982.60.129,0,Master of the Martyrdom of St. Sebastian
-1982.60.61,0,"Oeben, Jean-François"
-1982.60.61,1,Vandercruse Roger called Lacroix
-1982.60.81,0,"Roentgen, David"
-1982.60.81,1,"Zick, Januarius"
-1982.60.81,2,Gervais Elie
-1982.60.81,3,"Rémond, Pierre"
-1982.60.82,0,"Boulle, André Charles"
-1982.90.1a-c,0,"Rosenquist, James"
-1983.1009(8),0,"Matisse, Henri"
-1983.251,0,"Botero, Fernando"
+1982.60.61,0,Jean-François Oeben
+1982.60.61,1,"Roger Vandercruse, called Lacroix"
+1982.60.81,0,David Roentgen
+1982.60.81,1,Januarius Zick
+1982.60.81,2,Elie Gervais
+1982.60.81,3,Pierre Rémond
+1982.60.82,0,André Charles Boulle
+1982.90.1a-c,0,James Rosenquist
+1983.1009(8),0,Henri Matisse
+1983.251,0,Fernando Botero
 1983.356,0,Donatello
-1983.451,0,"Baldung, Hans (called Hans Baldung Grien)"
-1983.457,0,"Guston, Philip"
-1983.606.14–.22,0,"Warhol, Andy"
-"1983.619.1a, b",0,Saint Laurent Yves
-"1983.619.1a, b",1,"Saint Laurent Yves, Paris"
-"1983.8a, b",0,"Poiret, Paul"
-1984.114.1,0,Vuillaume Jean Baptiste
-"1984.163.4a, b",0,"Saint Laurent Yves, Paris"
-"1984.163.4a, b",1,Saint Laurent Yves
-1984.194,0,"Grooms, Red"
-1984.225,0,"Ertel, Giacomo (Jacob)"
+1983.451,0,Hans Baldung (called Hans Baldung Grien)
+1983.457,0,Philip Guston
+1983.606.14–.22,0,Andy Warhol
+"1983.619.1a, b",0,Yves Saint Laurent
+"1983.619.1a, b",1,"Yves Saint Laurent, Paris"
+"1983.8a, b",0,Paul Poiret
+1984.114.1,0,Jean Baptiste Vuillaume
+"1984.163.4a, b",0,"Yves Saint Laurent, Paris"
+"1984.163.4a, b",1,Yves Saint Laurent
+1984.194,0,Red Grooms
+1984.225,0,Giacomo (Jacob) Ertel
 1984.256,0,Fulper Pottery Company
-1984.3,0,"Chanel, Gabrielle ""Coco"""
-1984.3,1,"Chanel, House of"
-1984.315.42,0,"Klee, Paul"
-1984.328a-d,0,"Caro, Anthony"
-1984.331.13,0,"Munro, Rebekah S."
-1984.34,0,Hofmann Ferdinand
-1984.425,0,"Bennett, John"
-1984.433.16,0,"Matisse, Henri"
-1984.433.294,0,"Schiele, Egon"
-1984.433.298ab,0,"Schiele, Egon"
-1984.433.34,0,"Lachaise, Gaston"
-1984.459.1,0,"Sweerts, Michiel"
+1984.3,0,"Gabrielle ""Coco"" Chanel"
+1984.3,1,House of Chanel
+1984.315.42,0,Paul Klee
+1984.328a-d,0,Anthony Caro
+1984.331.13,0,Rebekah S. Munro
+1984.34,0,Ferdinand Hofmann
+1984.425,0,John Bennett
+1984.433.16,0,Henri Matisse
+1984.433.294,0,Egon Schiele
+1984.433.298ab,0,Egon Schiele
+1984.433.34,0,Gaston Lachaise
+1984.459.1,0,Michiel Sweerts
 1984.459.2,0,Guercino (Giovanni Francesco Barbieri)
-1984.527,0,"Avery, Milton"
-1984.613.2,0,"De Kooning, Willem"
-1985.114,0,"Lalique, René-Jules"
-1985.116,0,"Pabst, Daniel"
-1985.124,0,Tielke Joachim
-1985.353,0,"Saint-Gaudens, Augustus"
-1985.63.5,0,"Rothko, Mark"
-1986.1053.1,0,"Brandt, Bill"
-1986.1054.19,0,"O'Sullivan, Timothy H."
-1986.1159,0,"Mantegna, Andrea"
-1986.1225.2,0,"Kertész, André"
-1986.138,0,"Lotto, Lorenzo"
-1986.237,0,Boston and Sandwich Glass Company
-1986.239,0,Kintzing Christian
-"1986.265.1, .2",0,Grecke Johan Adolph
+1984.527,0,Milton Avery
+1984.613.2,0,Willem de Kooning
+1985.114,0,René-Jules Lalique
+1985.116,0,Daniel Pabst
+1985.124,0,Joachim Tielke
+1985.353,0,Augustus Saint-Gaudens
+1985.63.5,0,Mark Rothko
+1986.1053.1,0,Bill Brandt
+1986.1054.19,0,Timothy H. O'Sullivan
+1986.1159,0,Andrea Mantegna
+1986.1225.2,0,André Kertész
+1986.138,0,Lorenzo Lotto
+1986.237,0,Boston & Sandwich Glass Company
+1986.239,0,Christian Kintzing
+"1986.265.1, .2",0,Johan Adolph Grecke
 1986.266.4,0,Wu Bin
-1986.353.1,0,"Hauser, Hermann"
-1986.353.2,0,"Ramírez, Manuel"
-1986.365.3,0,Oppenordt Alexandre-Jean
-1986.365.3,1,"Berain, Jean"
-1986.397,0,"Bourgeois, Louise"
-1986.441.3,0,"Still, Clyfford"
-1987.1100.1,0,"Sheeler, Charles"
-1987.1100.10,0,"Strand, Paul"
-1987.1100.13,0,"Coburn, Alvin Langdon"
-1987.1100.384,0,"Abbott, Berenice"
+1986.353.1,0,Hermann Hauser
+1986.353.2,0,Manuel Ramírez
+1986.365.3,0,Alexandre-Jean Oppenordt
+1986.365.3,1,Jean Berain
+1986.397,0,Louise Bourgeois
+1986.441.3,0,Clyfford Still
+1987.1100.1,0,Charles Sheeler
+1987.1100.10,0,Paul Strand
+1987.1100.13,0,Alvin Langdon Coburn
+1987.1100.384,0,Berenice Abbott
 1987.1100.40,0,Man Ray
-1987.1100.47,0,"Lissitzky, El"
-1987.1100.476,0,"Feininger, T. Lux"
-1987.1100.48,0,"Kertész, André"
-1987.1100.482,0,"Evans, Walker"
+1987.1100.47,0,El Lissitzky
+1987.1100.476,0,T. Lux Feininger
+1987.1100.48,0,André Kertész
+1987.1100.482,0,Walker Evans
 1987.1100.49,0,Umbo (Otto Umbehr)
-1987.1100.87,0,"Model, Lisette"
-1987.1161,0,"Braun, Adolphe"
-1987.12,0,"Müller, Karl L. H."
-1987.282,0,"Close, Chuck"
-1987.455.2,0,"Klee, Paul"
-1987.47.1,0,"Degas, Edgar"
-1987.88,0,"Warhol, Andy"
-1988.103,0,"Evans, Walker"
-1988.1031,0,"Cuvelier, Eugène"
-1988.159,0,"von Hagenau, Nikolaus"
+1987.1100.87,0,Lisette Model
+1987.1161,0,Adolphe Braun
+1987.12,0,Karl L. H. Müller
+1987.282,0,Chuck Close
+1987.455.2,0,Paul Klee
+1987.47.1,0,Edgar Degas
+1987.88,0,Andy Warhol
+1988.103,0,Walker Evans
+1988.1031,0,Eugène Cuvelier
+1988.159,0,Nikolaus von Hagenau
 1988.162,0,Canaletto (Giovanni Antonio Canal)
 1988.164,0,Hukin & Heath
-1988.164,1,"Dresser, Christopher"
+1988.164,1,Christopher Dresser
 1988.294.1,0,Meissen Manufactory
-1988.294.1,1,Kirchner Johann Gottlieb
+1988.294.1,1,Johann Gottlieb Kirchner
 1988.65.1–.2,0,Hallé
-1988.74.2a–e,0,"Gernreich, Rudi"
-1988.87,0,Tecchler David
-1989.1038.2,0,"Klein, William"
-1989.1063,0,"Greene, John Beasley"
-1989.1083,0,"Watkins, Carleton E."
-1989.1135,0,"Strand, Paul"
-1989.147,0,Voboam Jean-Baptiste
-1989.183,0,"Gericault, Théodore"
-1989.197,0,Diehl Charles-Guillaume
-1989.197,1,Frémiet Emmanuel
-1989.197,2,Brandely Jean
+1988.74.2a–e,0,Rudi Gernreich
+1988.87,0,David Tecchler
+1989.1038.2,0,William Klein
+1989.1063,0,John Beasley Greene
+1989.1083,0,Carleton E. Watkins
+1989.1135,0,Paul Strand
+1989.147,0,Jean-Baptiste Voboam
+1989.183,0,Théodore Gericault
+1989.197,0,Charles-Guillaume Diehl
+1989.197,1,Emmanuel Frémiet
+1989.197,2,Jean Brandely
 1989.281.72,0,Achilles Painter
-1989.3,0,"Drouart, Jean"
-1989.363.4,0,HUANG TINGJIAN
-1990.1005,0,"Lange, Dorothea"
-1990.103,0,"Sellas, Matteo"
-1990.1083,0,"Metzker, Ray K."
-1990.113,0,"Le Secq, Henri-Jean-Louis"
-1990.223,0,Norman Barak
-1990.226a–d,0,"Revere, Paul, Jr."
-1990.237a-c,0,"Ringgold, Faith"
+1989.3,0,Jean Drouart
+1989.363.4,0,Huang Tingjian
+1990.1005,0,Dorothea Lange
+1990.103,0,Matteo Sellas
+1990.1083,0,Ray K. Metzker
+1990.113,0,Henri-Jean-Louis Le Secq
+1990.223,0,Barak Norman
+1990.226a–d,0,Paul Revere Jr.
+1990.237a-c,0,Faith Ringgold
 1990.247,0,"Pacetti, Vincenzo"
-1990.38.1,0,"Boccioni, Umberto"
-1990.38.3,0,"Boccioni, Umberto"
-1991.1044,0,"Robert, Louis-Rémy"
-1991.1056,0,"Steinert, Otto"
-1991.1127,0,"Fuss, Adam"
+1990.38.1,0,Umberto Boccioni
+1990.38.3,0,Umberto Boccioni
+1991.1044,0,Louis-Rémy Robert
+1991.1056,0,Otto Steinert
+1991.1127,0,Adam Fuss
 1991.1198,0,Nadar
-1991.1232,0,"Sander, August"
-1991.1233,0,"Atget, Eugène"
-1991.145,0,"Price, William Lightfoot"
+1991.1232,0,August Sander
+1991.1233,0,Eugène Atget
+1991.145,0,William Lightfoot Price
 1991.311.1,0,Byrdcliffe Arts and Crafts Colony
-"1991.373a, b",0,Kunitoshi Rai
-1991.77,0,"Murray, Elizabeth"
-1992.128,0,"Guy, Seymour Joseph"
-1992.146,0,"Dix, Otto"
+"1991.373a, b",0,Rai Kunitoshi
+1991.77,0,Elizabeth Murray
+1992.128,0,Seymour Joseph Guy
+1992.146,0,Otto Dix
 1992.23,0,American Pottery Manufacturing Company
-1992.24.1,0,"Davis, Stuart"
-1992.24.3,0,"Hartley, Marsden"
-1992.24.8,0,"Sheeler, Charles"
-1992.269,0,"Hunzinger, George Jakob"
-1992.279,0,"de Frías, Joseph"
-1992.333,0,Tielke Joachim
-1992.391,0,"Picasso, Pablo"
-1992.43,0,"de Forest, Lockwood"
-1992.5,0,"Baldus, Édouard"
-1992.5067,0,"Matta-Clark, Gordon"
-1992.51,0,Habiballah
-1992.5107,0,"Winogrand, Garry"
-1992.5147,0,"Sherman, Cindy"
-1992.5149,0,"Steichen, Edward J."
-1992.5152,0,"Atget, Eugène"
-1992.5154,0,"Polke, Sigmar"
-1992.5158,0,"Bustamante, Jean-Marc"
+1992.24.1,0,Stuart Davis
+1992.24.3,0,Marsden Hartley
+1992.24.8,0,Charles Sheeler
+1992.269,0,George Jakob Hunzinger
+1992.279,0,Joseph de Frías
+1992.333,0,Joachim Tielke
+1992.391,0,Pablo Picasso
+1992.43,0,Lockwood de Forest
+1992.5,0,Édouard Baldus
+1992.5067,0,Gordon Matta-Clark
+1992.51,0,Habiballah of Sava
+1992.5107,0,Garry Winogrand
+1992.5147,0,Cindy Sherman
+1992.5149,0,Edward J. Steichen
+1992.5152,0,Eugène Atget
+1992.5154,0,Sigmar Polke
+1992.5158,0,Jean-Marc Bustamante
 1992.8,0,Herter Brothers
 "1992.8.1, .2",0,Sesson Shūkei
-1993.1097,0,"Altdorfer, Albrecht"
-1993.132,0,"Gogh, Vincent van"
-1993.14,0,"Tekelü, Ahmed"
-1993.195a–s,0,"Bush, Andrew"
-1993.303a-f,0,"Prutscher, Otto"
+1993.1097,0,Albrecht Altdorfer
+1993.132,0,Vincent van Gogh
+1993.14,0,Ahmed Tekelü
+1993.195a–s,0,Andrew Bush
+1993.303a-f,0,Otto Prutscher
 1993.303a-f,1,Beissbarth & Hoffmann
-1993.324,0,"Anshutz, Thomas"
-1993.332.2,0,"Foggini, Giovanni Battista"
-1993.393.1,0,"Balenciaga, Cristobal"
-1993.393.1,1,Balenciaga House of
-1993.400.6,0,"Braque, Georges"
-1993.415,0,"Bernard, Léopold"
-1993.415,1,"Brun, J. C. A."
-1993.415,2,"Tissot, Jean-Claude"
-1993.415,3,"Fannière, François-Auguste"
-1993.415,4,"Fannière, François-Joseph-Louis"
-1993.52.3,0,Versace Gianni
-1993.52.3,1,Gianni Versace
-1993.52.4,0,Versace Gianni
-1993.52.4,1,Gianni Versace
-1993.55,0,Fath Jacques
-1993.55,1,Fath House of Jacques
-1993.69.3,0,"Vallou-de-Villeneuve, Julien"
-1993.7,0,"Dijon, V."
-1993.71,0,"Freud, Lucian"
-1993.75,0,"Davenport, A. H."
-1993.75,1,"Bacon, Francis H."
-1993.96,0,"Yamamoto, Yohji"
-1994.12,0,"Mackintosh, Charles Rennie"
-1994.141,0,"Vali, Mustafa ibn"
+1993.324,0,Thomas Anshutz
+1993.332.2,0,Giovanni Battista Foggini
+1993.393.1,0,Cristobal Balenciaga
+1993.393.1,1,House of Balenciaga
+1993.400.6,0,Georges Braque
+1993.415,0,Léopold Bernard
+1993.415,1,J. C. A. Brun
+1993.415,2,Jean-Claude Tissot
+1993.415,3,François-Auguste Fannière
+1993.415,4,François-Joseph-Louis Fannière
+1993.52.3,0,Gianni Versace
+1993.52.4,0,Gianni Versace
+1993.55,0,Jacques Fath
+1993.55,1,House of Jacques Fath
+1993.69.3,0,Julien Vallou de Villeneuve
+1993.7,0,V. Dijon
+1993.71,0,Lucian Freud
+1993.75,0,A. H. Davenport
+1993.75,1,Francis H. Bacon
+1993.96,0,Yohji Yamamoto
+1994.12,0,Charles Rennie Mackintosh
+1994.141,0,Mustafa ibn Vali
 1994.141,1,Sultan Murad III
 1994.141,2,Mustafa b. Yusuf al-Darir al-Erzerumi
-1994.144.8,0,"Sugimoto, Hiroshi"
-1994.182,0,"Johnson, David"
-1994.245.135,0,"Evans, Walker"
-1994.269,0,"Henle, Jan"
-1994.271,0,"Atget, Eugène"
-1994.278,0,Lacroix Christian
-1994.278,1,"Patou, House of"
-1994.417,0,"Choiselat, Marie-Charles-Isidore & Stanislas Ratel"
-1994.417,1,"Ratel, Stanislas"
-1994.45,0,"Hassam, Childe"
-1994.486,0,"Léger, Fernand"
-1994.567,0,"Hassam, Childe"
-"1994.578.3a, b",0,Gaultier Jean Paul
-1994.76,0,"Wiles, Irving Ramsey"
+1994.144.8,0,Hiroshi Sugimoto
+1994.182,0,David Johnson
+1994.245.135,0,Walker Evans
+1994.269,0,Jan Henle
+1994.271,0,Eugène Atget
+1994.278,0,Christian Lacroix
+1994.278,1,House of Patou
+1994.417,0,Marie-Charles-Isidore Choiselat
+1994.417,1,Stanislas Ratel
+1994.45,0,Childe Hassam
+1994.486,0,Fernand Léger
+1994.567,0,Childe Hassam
+"1994.578.3a, b",0,Jean Paul Gaultier
+1994.76,0,Irving Ramsey Wiles
 1994.83,0,Unknown
-1995.101,0,"Fragonard, Jean Honoré"
-1995.12,0,"Orley, Bernard van"
+1995.101,0,Jean Honoré Fragonard
+1995.12,0,Bernard van Orley
 1995.13,0,"Bakewell, Page & Bakewell"
-1995.14.5,0,"Kiefer, Anselm"
-1995.142,0,"Dubuffet, Jean"
-1995.15,0,"Brueghel, Jan, the Elder"
-1995.191,0,"Gursky, Andreas"
-1995.196,0,"Ruisdael, Jacob van"
-1995.213a–h,0,"Westwood, Vivienne"
-1995.234,0,"Baziotes, William"
+1995.14.5,0,Anselm Kiefer
+1995.142,0,Jean Dubuffet
+1995.15,0,Jan Brueghel the Elder
+1995.191,0,Andreas Gursky
+1995.196,0,Jacob van Ruisdael
+1995.213a–h,0,Vivienne Westwood
+1995.234,0,William Baziotes
 1995.245.1,0,Valentina
-1995.251,0,"Warhol, Andy"
-1995.336,0,"Colt, Samuel"
-"1995.371a, b",0,Mekeren Jan van
-1995.377.1,0,"Lannuier, Charles-Honoré"
-1995.378,0,"Homer, Winslow"
-1995.440a-c,0,"Zeisel, Eva"
+1995.251,0,Andy Warhol
+1995.336,0,Samuel Colt
+"1995.371a, b",0,Jan van Mekeren
+1995.377.1,0,Charles-Honoré Lannuier
+1995.378,0,Winslow Homer
+1995.440a-c,0,Eva Zeisel
 1995.440a-c,1,Schramberg Majolica Factory
-1995.474,0,"Ray, Charles"
-1995.595,0,"Krasner, Lee"
-1995.72.7,0,Teng Yeohlee
-1995.96.10,0,"Bacot, Edmond"
-1996.102,0,"Coleman, Charles Caryl"
-1996.13.1,0,"Oberlender, Johann Wilhelm"
-1996.14,0,"Gerhaert von Leyden, Niclaus"
-1996.279,0,"Copley, John Singleton"
-1996.291a–c,0,"Callahan, Harry"
-1996.297,0,"Struth, Thomas"
-1996.299,0,"Arbus, Diane"
-1996.322,0,"Woodman, Francesca"
-1996.363.2,0,"Robert, Louis-Rémy"
-"1996.364a, b",0,"Verona, Stefano da"
-1996.382,0,"Hassam, Childe"
-1996.403.1,0,"Picasso, Pablo"
-1996.403.10,0,"Chirico, Giorgio de"
-1996.403.7ab,0,"Brancusi, Constantin"
-1996.403.8,0,"Miró, Joan"
-1996.418,0,"Gauguin, Paul"
+1995.474,0,Charles Ray
+1995.595,0,Lee Krasner
+1995.72.7,0,Yeohlee Teng
+1995.96.10,0,Edmond Bacot
+1996.102,0,Charles Caryl Coleman
+1996.13.1,0,Johann Wilhelm Oberlender (the Elder)
+1996.14,0,Niclaus Gerhaert von Leyden
+1996.279,0,John Singleton Copley
+1996.291a–c,0,Harry Callahan
+1996.297,0,Thomas Struth
+1996.299,0,Diane Arbus
+1996.322,0,Francesca Woodman
+1996.363.2,0,Louis-Rémy Robert
+"1996.364a, b",0,Stefano da Verona (Stefano di Giovanni)
+1996.382,0,Childe Hassam
+1996.403.1,0,Pablo Picasso
+1996.403.10,0,Giorgio de Chirico
+1996.403.7ab,0,Constantin Brancusi
+1996.403.8,0,Joan Miró
+1996.418,0,Paul Gauguin
 1996.480.3,0,Halston
 1996.558,0,Olowe of Ise
-1996.561,0,"Proctor, Alexander Phimister"
-1996.563,0,"Benbridge, Henry"
-1996.99.2,0,"Cameron, Julia Margaret"
-1997.108,0,"Faigenbaum, Patrick"
-1997.117.10,0,"Ostade, Adriaen van"
-1997.149.12,0,"Braque, Georges"
-1997.149.9,0,"Modigliani, Amedeo"
+1996.561,0,Alexander Phimister Proctor
+1996.563,0,Henry Benbridge
+1996.99.2,0,Julia Margaret Cameron
+1997.108,0,Patrick Faigenbaum
+1997.117.10,0,Adriaen van Ostade
+1997.149.12,0,Georges Braque
+1997.149.9,0,Amedeo Modigliani
 1997.153,0,Raphael (Raffaello Sanzio or Santi)
 1997.156,0,Claude Lorrain (Claude Gellée)
 1997.167,0,Caravaggio (Michelangelo Merisi)
-1997.195,0,"Fuss, Adam"
-1997.207,0,"Cassatt, Mary"
-1997.228,0,Itoh Takuo
-1997.25,0,"Strand, Paul"
-1997.250.6,0,Kang Ji
+1997.195,0,Adam Fuss
+1997.207,0,Mary Cassatt
+1997.228,0,Takuo Itoh
+1997.25,0,Paul Strand
+1997.250.6,0,Ji Eon Kang
 1997.36,0,Polyteleia Painter
-1997.382.1,0,"Talbot, William Henry Fox"
-1997.382.19,0,"Hill, David Octavius"
-1997.382.19,1,"Adamson, Robert"
+1997.382.1,0,William Henry Fox Talbot
+1997.382.19,0,David Octavius Hill
+1997.382.19,1,Robert  Adamson
 1997.382.19,2,Hill and Adamson
-1997.382.34,0,"Fenton, Roger"
-1997.382.35,0,"Fenton, Roger"
-1997.382.38,0,"Cameron, Julia Margaret"
-1997.382.41,0,"Whipple, John Adams"
-1997.382.46,0,"Moulin, Félix-Jacques-Antoine"
-1997.460.1a–d,0,MEMPHIS MILANO
-1997.460.1a–d,1,"Sottsass, Ettore"
-1997.4ab,0,"Kiefer, Anselm"
-1997.61.19,0,"Stieglitz, Alfred"
-1997.61.25,0,"Stieglitz, Alfred"
-1997.93,0,"Spranger, Bartholomeus"
-1998.121,0,"Pons, Joseph"
-1998.132,0,"Nègre, Charles"
-1998.21,0,"Ingres, Jean Auguste Dominique"
-1998.21,1,"Kaunitz-Rietberg, Prince Wenzel von"
-1998.225,0,"Poussin, Nicolas"
-1998.311.1,0,"Smith, David"
-1998.329,0,"Johns, Jasper"
-1998.338,0,"Chauvassaignes, Franck-François-Genès"
-1998.365,0,"Sargent, John Singer"
-1998.431.1a–e,0,"Rosenquist, James"
+1997.382.34,0,Roger Fenton
+1997.382.35,0,Roger Fenton
+1997.382.38,0,Julia Margaret Cameron
+1997.382.41,0,John Adams Whipple
+1997.382.46,0,Félix-Jacques-Antoine Moulin
+1997.460.1a–d,0,Memphis Milano
+1997.460.1a–d,1,Ettore Sottsass
+1997.4ab,0,Anselm Kiefer
+1997.61.19,0,Alfred Stieglitz
+1997.61.25,0,Alfred Stieglitz
+1997.93,0,Bartholomeus Spranger
+1998.121,0,Joseph Pons
+1998.132,0,Charles Nègre
+1998.21,0,Jean Auguste Dominique Ingres
+1998.21,1,Prince Wenzel von Kaunitz-Rietberg
+1998.225,0,Nicolas Poussin
+1998.311.1,0,David Smith
+1998.329,0,Jasper Johns
+1998.338,0,Franck-François-Genès Chauvassaignes
+1998.365,0,John Singer Sargent
+1998.431.1a–e,0,James Rosenquist
 1998.431.1a–e,1,Hugo Boss
 1998.479,0,Simca Print Artists Inc.
-1998.479,1,"Johns, Jasper"
-"1998.493.189a, b",0,Sant'Angelo Giorgio
-1998.57,0,"Tournachon, Adrien"
+1998.479,1,Jasper Johns
+"1998.493.189a, b",0,Giorgio di Sant'Angelo
+1998.57,0,Adrien Tournachon
 1998.57,1,Nadar
-1998.57,2,"Deburau, Jean-Charles"
-1998.7,0,Pere Alexandre & Fils
+1998.57,2,Jean-Charles Deburau
+1998.7,0,Alexandre Pere & Fils
 1999.103,0,Ezra
-1999.176,0,"Dewing, Thomas Wilmer"
-1999.18,0,"Mead, Larkin Goldsmith"
-1999.19,0,"Farrer, Henry"
-1999.2,0,"Muniz, Vik"
-1999.21,0,"Ruff, Thomas"
-1999.222,0,"Rubens, Peter Paul"
-1999.237.4,0,"Evans, Walker"
-1999.24,0,"Rovner, Michal"
-1999.26,0,Amati Andrea
-1999.27.1a-c-5,0,"Saarinen, Eliel"
-1999.27.1a-c-5,1,WILCOX SILVER
-"1999.307 a,b",0,"Porthaux, Dominique Antony"
-1999.363.15,0,"Chirico, Giorgio de"
-1999.363.16,0,"Dalí, Salvador"
-1999.363.20,0,"Dubuffet, Jean"
-1999.363.22,0,"Giacometti, Alberto"
-1999.363.41,0,"Matisse, Henri"
-1999.363.50,0,"Miró, Joan"
-1999.363.53,0,"Miró, Joan"
-1999.38,0,"Abbott, Berenice"
-1999.396,0,"Belter, J. H."
-1999.399,0,"Adhikari, Murari"
-1999.494a–h,0,Galliano John
-1999.494a–h,1,"Dior, House of"
-1999.58a–d,0,"Jacobs, Marc"
-1999.58a–d,1,Vuitton Louis
+1999.176,0,Thomas Wilmer Dewing
+1999.18,0,Larkin Goldsmith Mead
+1999.19,0,Henry Farrer
+1999.2,0,Vik Muniz
+1999.21,0,Thomas Ruff
+1999.222,0,Peter Paul Rubens
+1999.237.4,0,Walker Evans
+1999.24,0,Michal Rovner
+1999.26,0,Andrea Amati
+1999.27.1a-c-5,0,Eliel Saarinen
+1999.27.1a-c-5,1,"International Silver Company, Wilcox Silver Plate Company Division (Meriden, Connecticut)"
+"1999.307 a,b",0,Dominique Antony Porthaux
+1999.363.15,0,Giorgio de Chirico
+1999.363.16,0,Salvador Dalí
+1999.363.20,0,Jean Dubuffet
+1999.363.22,0,Alberto Giacometti
+1999.363.41,0,Henri Matisse
+1999.363.50,0,Joan Miró
+1999.363.53,0,Joan Miró
+1999.38,0,Berenice Abbott
+1999.396,0,John H. Belter
+1999.399,0,Murari Adhikari
+1999.494a–h,0,John Galliano
+1999.494a–h,1,House of Dior
+1999.58a–d,0,Marc Jacobs
+1999.58a–d,1,Louis Vuitton Co.
 1999.93,0,Prince Lu
-20.155.1,0,"Gainsborough, Thomas"
-20.155.11,0,"Riesener, Jean Henri"
-20.155.3,0,"Reynolds, Joshua, Sir"
-20.155.8,0,"Greuze, Jean-Baptiste"
-20.155.9,0,"Boucher, François"
-20.24.76,0,"Peruzzi, Baldassare Tommaso"
-20.24.76,1,"Carpi, Ugo da"
-2000.127,0,"Lonberg-Holm, Knud"
-2000.13,0,"Le Gray, Gustave"
-2000.151,0,"Peale, Rembrandt"
-2000.272,0,"Prince, Richard"
-2000.278.1-.9,0,"Hoffmann, Josef"
+20.155.1,0,Thomas Gainsborough
+20.155.11,0,Jean Henri Riesener
+20.155.3,0,Sir Joshua Reynolds
+20.155.8,0,Jean-Baptiste Greuze
+20.155.9,0,François Boucher
+20.24.76,0,Baldassare Tommaso Peruzzi
+20.24.76,1,Ugo da Carpi
+2000.127,0,Knud Lonberg-Holm
+2000.13,0,Gustave Le Gray
+2000.151,0,Rembrandt Peale
+2000.272,0,Richard Prince
+2000.278.1-.9,0,Josef Hoffmann
 2000.278.1-.9,1,Wiener Werkstätte
-2000.51,0,"Friedrich, Caspar David"
-2000.512,0,"Whistler, James McNeill"
-2000.600.15,0,"Rohde, Gilbert"
-2000.600.15,1,"Miller, Herman Inc."
-2000.63a-c,0,"Brandt, Marianne"
-2001.153,0,"Hannock, Stephen"
-2001.293,0,"Smithson, Robert"
-2001.402a,0,"Tanner, Henry Ossawa"
-2001.474,0,"Arbus, Diane"
-2001.608.1,0,"Homer, Winslow"
-2001.641,0,"Saint-Gaudens, Augustus"
+2000.51,0,Caspar David Friedrich
+2000.512,0,James McNeill Whistler
+2000.600.15,0,Gilbert Rohde
+2000.600.15,1,"The Herman Miller Furniture Company, Zeeland, MI"
+2000.63a-c,0,Marianne Brandt
+2001.153,0,Stephen Hannock
+2001.293,0,Robert Smithson
+2001.402a,0,Henry Ossawa Tanner
+2001.474,0,Diane Arbus
+2001.608.1,0,Winslow Homer
+2001.641,0,Augustus Saint-Gaudens
 2001.642,0,Bamen Tomotsugu
-2001.723,0,"Fouquet, Georges"
+2001.723,0,Georges Fouquet
 "2001.742a, b",0,Comme des Garçons
-"2001.742a, b",1,Watanabe Junya
-2002.1,0,"West, Benjamin"
-2002.115,0,Imperial Armory
+"2001.742a, b",1,Junya Watanabe
+2002.1,0,Benjamin West
+2002.115,0,"Imperial Armory, Tula (south of Moscow), Russia"
 2002.190a–n,0,Courtois frères
-2002.21.1,0,"Rush, William"
-2002.259,0,"Kilburn, (or Kilbrunn) Lawrence"
-2002.26,0,"Friedrich, Caspar David"
-2002.323 a-f,0,Langenbucher Veit
-2002.323 a-f,1,"Bidermann, Samuel"
-2002.365,0,"Ruhlmann, Émile-Jacques"
-2002.365,1,"Gaudissard, Emile"
-2002.436,0,"Lorenzetti, Pietro"
-2002.456.1,0,"Carrington, Leonora"
-2002.456.111,0,"Giacometti, Alberto"
-2002.468,0,Permoser Balthasar
+2002.21.1,0,William Rush
+2002.259,0,Lawrence Kilburn (or Kilbrunn)
+2002.26,0,Caspar David Friedrich
+2002.323 a-f,0,Veit Langenbucher
+2002.323 a-f,1,Samuel Bidermann
+2002.365,0,Émile-Jacques Ruhlmann
+2002.365,1,Emile Gaudissard
+2002.436,0,Pietro Lorenzetti
+2002.456.1,0,Leonora Carrington
+2002.456.111,0,Alberto Giacometti
+2002.468,0,Balthasar Permoser
 "2003.12a, b",0,Studio 65
 "2003.12a, b",1,Gufram
-2003.150a–g,0,Esposito Giosue
+2003.150a–g,0,Giosue Esposito
 2003.241,0,'Abd al-Qadir Hisari
-2003.269,0,"Hammons, David"
-2003.27,0,"Matta, Roberto"
-2003.323,0,"Graf, Urs"
+2003.269,0,David Hammons
+2003.27,0,Roberto Matta
+2003.323,0,Urs Graf
 2003.442,0,Gucci
-2003.442,1,Ford Tom
+2003.442,1,Tom Ford
 2003.462,0,Alexander McQueen
-2003.462,1,McQueen Alexander
 2003.63a–d,0,Unknown
-"2003.68a, b",0,Armani Giorgio
+"2003.68a, b",0,Giorgio Armani
 2004.442,0,Duccio di Buoninsegna
-2005.100.1,0,"Aguado de las Marismas, Onésipe"
-2005.100.109,0,"Watkins, Carleton E."
-2005.100.116,0,"Seeley, George H."
+2005.100.1,0,Onésipe Aguado de las Marismas
+2005.100.109,0,Carleton E. Watkins
+2005.100.116,0,George Seeley
 2005.100.140,0,Man Ray
-2005.100.27,0,"Cameron, Julia Margaret"
-2005.364.1a–d–.48,0,Fourteen identified German (Augsburg) goldsmiths and other Germa
+2005.100.27,0,Julia Margaret Cameron
+2005.364.1a–d–.48,0,Fourteen identified German (Augsburg) goldsmiths and other German artisans; Japanese (Imari) porcelain maker
 2005.365,0,Garion
-2005.390a-c,0,"Rauschenberg, Robert"
-2005.44.2,0,Adrover Miguel
-2006.277a-fff,0,"Tinguely, Jean"
-2006.32.15,0,"Ernst, Max"
-2006.32.49,0,"Oldenburg, Claes"
-2006.32.5,0,"Calder, Alexander"
-"2006.420.51a, b",0,Saint Laurent Yves
-"2006.420.51a, b",1,"Saint Laurent Yves, Paris"
-2006.452a–c,0,Redlin Michel
-"2006.519a, b",0,"Dugourc, Jean Démosthène"
-"2006.519a, b",1,"Pernon, Camille"
-2006.86a–c,0,"Scherer, Georg Henrich"
-2006.91,0,"Wall, Jeff"
-2007.194a–f,0,Teijo Goto
+2005.390a-c,0,Robert Rauschenberg
+2005.44.2,0,Miguel Adrover
+2006.277a-fff,0,Jean Tinguely
+2006.32.15,0,Max Ernst
+2006.32.49,0,Claes Oldenburg
+2006.32.5,0,Alexander Calder
+"2006.420.51a, b",0,Yves Saint Laurent
+"2006.420.51a, b",1,"Yves Saint Laurent, Paris"
+2006.452a–c,0,Michel Redlin
+"2006.519a, b",0,Jean Démosthène Dugourc
+"2006.519a, b",1,Camille Pernon
+2006.86a–c,0,Georg Henrich Scherer
+2006.91,0,Jeff Wall
+2007.194a–f,0,"Metalwork by Goto Teijo, 9th generation Goto master, Japan"
 2007.194a–f,1,Gotō Yūjō
-2007.27,0,"Hoentschel, Georges"
-2007.27,1,Grittel Èmile
+2007.27,0,Georges Hoentschel
+2007.27,1,Èmile Grittel
 2007.329,0,Unidentified Artist
-2007.442,0,"Voiriot, Guillaume"
-2007.95,0,"Hepworth, Barbara"
-2007.96,0,"Anatsui, El"
-2008.1,0,Grancino Giovanni
-2008.121,0,"Anatsui, El"
-2008.253,0,"Leyden, Lucas van"
+2007.442,0,Guillaume Voiriot
+2007.95,0,Barbara Hepworth
+2007.96,0,El Anatsui
+2008.1,0,Giovanni Grancino
+2008.121,0,El Anatsui
+2008.253,0,Lucas van Leyden
 2008.278,0,Hans of Landshut
-2008.29,0,"Kapoor, Anish"
+2008.29,0,Anish Kapoor
 2008.312,0,Bhawani Das
 2008.459,0,Valentin de Boulogne
-2008.547.1,0,"Gérôme, Jean-Léon"
+2008.547.1,0,Jean-Léon Gérôme
 2009.28,0,Anonymous
-2009.28,1,"Amman, Jost"
+2009.28,1,Jost Amman
 2009.28,2,Anonymous Flemish weavers
-2009.300.816,0,James Charles
-2009.58,0,"Briosco, Andrea, called Riccio"
-2009.8a–c,0,"Jackson, Samuel"
-201.9 Av3,0,"Avery, Samuel Putnam, Sr."
-201.9Av3 Av32,0,"Avery, Samuel Putnam, Sr."
-201.9F88 B73,0,Brainerd Ira Hutchinson
-2010.121,0,"Struth, Thomas"
-2010.138.1-.4,0,Bunsen Franz Peter
-2010.23,0,"Gros, Jean-Baptiste-Louis"
-2010.24,0,"Messerschmidt, Franz Xaver"
-2010.466,0,"Fitch, Julia Ann"
+2009.300.816,0,Charles James
+2009.58,0,"Andrea Briosco, called Riccio"
+2009.8a–c,0,Samuel Jackson
+201.9 Av3,0,Samuel Putnam Avery Sr.
+201.9Av3 Av32,0,Samuel Putnam Avery Sr.
+201.9F88 B73,0,Ira Hutchinson Brainerd
+2010.121,0,Thomas Struth
+2010.138.1-.4,0,Franz Peter Bunsen
+2010.23,0,Baron Jean-Baptiste-Louis Gros
+2010.24,0,Franz Xaver Messerschmidt
+2010.466,0,Julia Ann Fitch
 2011.36,0,Perino del Vaga (Pietro Buonaccorsi)
-2012.99,0,"Bassano, Jacopo (Jacopo da Ponte)"
-2014.173,0,"Enríquez, Nicolás"
-2014.269,0,"Rodríguez Juárez, Juan"
-21.115.4,0,"Whittredge, Worthington"
-21.164,0,"Glackens, William James"
-216.7 T71,0,"Andrews, William Loring"
-216.7 T71,1,Berners Juliana
-217.08  W881,0,Woolnough Charles W.
-22.16.17,0,"Cassatt, Mary"
-"22.19a, b",0,"Targee, John"
-22.207,0,"Homer, Winslow"
-22.61,0,"MacMonnies, Frederick William"
-22.75,0,"Sarto, Andrea del (Andrea d'Agnolo)"
-221.1 K63,0,Kirchner Athanasius
-226 B641,0,"Buonanni, Filippo"
-23.101,0,"Cassatt, Mary"
-23.102,0,"Healy, George P. A."
-23.163.4a,0,"Morris, William"
+2012.99,0,Jacopo Bassano (Jacopo da Ponte)
+2014.173,0,Nicolás Enríquez
+2014.269,0,Juan Rodríguez Juárez
+21.115.4,0,Worthington Whittredge
+21.164,0,William James Glackens
+216.7 T71,0,William Loring Andrews
+216.7 T71,1,Juliana Berners
+217.08  W881,0,Charles W. Woolnough
+22.16.17,0,Mary Cassatt
+"22.19a, b",0,John Targee
+22.207,0,Winslow Homer
+22.61,0,Frederick William MacMonnies
+22.75,0,Andrea del Sarto (Andrea d'Agnolo)
+221.1 K63,0,Athanasius Kircher
+226 B641,0,Filippo Buonanni
+23.101,0,Mary Cassatt
+23.102,0,George P. A. Healy
+23.163.4a,0,William Morris
 23.163.4a,1,Morris & Company
 23.163.4a,2,Jeffrey & Co.
-23.31.1,0,"Picasso, Pablo"
-23.31.1,1,"Fort, Louis"
-23.31.1,2,"Vollard, Ambroise"
+23.31.1,0,Pablo Picasso
+23.31.1,1,Louis Fort
+23.31.1,2,Ambroise Vollard
 230.51 N55,0,Tong zhi tang
-230.51 N55,1,"Nie, Chongyi"
-239 B63 Q,0,Boch Jean
-239 B63 Q,1,"Borcht, Peeter van der"
-"24.179; 26.188.1, .2; 29.158.363a, b",0,"Helmschmid, Kolman"
+230.51 N55,1,Chongyi Nie
+239 B63 Q,0,Jean Boch
+239 B63 Q,1,Peeter van der Borcht
+"24.179; 26.188.1, .2; 29.158.363a, b",0,Kolman Helmschmid
 24.197.2,0,Michelangelo Buonarroti
-24.241.2,0,Toft Thomas
-24.45.1,0,"Poussin, Nicolas"
+24.241.2,0,Thomas Toft
+24.45.1,0,Nicolas Poussin
 24.97.104,0,Tarporley Painter
-240.7 T344 F,0,Elseviers
-240.7 T344 F,1,Boslwert A.
-240.7 T344 F,2,Thibault Girard
-25.115.15,0,"Armitt, Joseph"
+240.7 T344 F,0,probably the Elseviers of Leyden
+240.7 T344 F,1,probably A. Boslwert
+240.7 T344 F,2,Girard Thibault
+25.115.15,0,Joseph Armitt
 25.120.288,0,Bartolo di Fredi
-25.17,0,"Ostendorfer, Michael"
-25.17,1,"Apianus, Petrus"
-25.17,2,"Apianus, Georg and Petrus"
-25.231.1,0,"Ruhlmann, Émile-Jacques"
+25.17,0,Michael Ostendorfer
+25.17,1,Petrus Apianus
+25.17,2,Georg and Petrus Apianus
+25.231.1,0,Émile-Jacques Ruhlmann
 25.78.56,0,Polykleitos
-250 T34,0,"Dézallier d'Argenville, Antoine Joseph"
-254 B63,0,"Böckler, Georg Andreas"
-26.117,0,Kōrin
-26.12,0,"French, Daniel Chester"
-"26.145.243a, b",0,"Deutschmann, Joseph"
-"26.145.315a, b",0,Morisset James
-26.168.77,0,"Biennais, Martin-Guillaume"
-26.168.77,1,"Percier, Charles"
-26.168.77,2,Jacob-Desmalter François-Honoré-Georges
-26.168.77,3,"Denon, Dominique Vivant Baron"
+250 T34,0,Antoine Joseph Dézallier d'Argenville
+254 B63,0,Georg Andreas Böckler
+26.117,0,Ogata Kōrin
+26.12,0,Daniel Chester French
+"26.145.243a, b",0,Joseph Deutschmann
+"26.145.315a, b",0,James Morisset
+26.168.77,0,Martin-Guillaume Biennais
+26.168.77,1,Charles Percier
+26.168.77,2,François-Honoré-Georges Jacob-Desmalter
+26.168.77,3,baron Dominique Vivant Denon
 26.49,0,Nearchos
-26.54,0,Webb Philip
-26.54,1,"Burne-Jones, Edward, Sir"
+26.54,0,Philip Webb
+26.54,1,Sir Edward Burne-Jones
 26.54,2,"Morris, Marshall, Faulkner & Co."
-26.72.68,0,"Altdorfer, Albrecht"
-26.9,0,"Böcklin, Arnold"
-26.97,0,"Johnson, Eastman"
-27.137,0,"Zurbarán, Francisco de"
-270.52 T49,0,"Hunter, Dard"
+26.72.68,0,Albrecht Altdorfer
+26.9,0,Arnold Böcklin
+26.97,0,Eastman Johnson
+27.137,0,Francisco de Zurbarán
+270.52 T49,0,Dard Hunter
 270.52 T49,1,"Tindale, Thomas & Harriet R."
-272.4 Au8,0,"Avery, Samuel Putnam, Sr."
-273.4 G76,0,"Grand-Carteret, John"
-273.4 G76,1,"Régamey, Félix"
-273.4D26 AL2,0,"Daumier, Honoré"
-273.4D26 AL2,1,"Alexandre, Arsène"
-28.221,0,"Cranach, Lucas, the Elder"
-"28.52a, b",0,New Bremen Glass Manufactory 
-"28.52a, b",1,"Amelung, John Frederick"
+272.4 Au8,0,Samuel Putnam Avery Sr.
+273.4 G76,0,John Grand-Carteret
+273.4 G76,1,Félix Régamey
+273.4D26 AL2,0,Honoré Daumier
+273.4D26 AL2,1,Arsène Alexandre
+28.221,0,Lucas Cranach the Elder
+"28.52a, b",0,New Bremen Glass Manufactory
+"28.52a, b",1,John Frederick Amelung
 28.57.23,0,Persephone Painter
-29.100.115,0,"Manet, Édouard"
-29.100.129,0,"Daumier, Honoré"
+29.100.115,0,Édouard Manet
+29.100.129,0,Honoré Daumier
 29.100.16,0,Bronzino (Agnolo di Cosimo di Mariano)
-29.100.200,0,"Daumier, Honoré"
-29.100.23,0,"Ingres, Jean Auguste Dominique"
-29.100.370,0,"Degas, Edgar"
-29.100.370,1,HÉBRARD A. A.
-29.100.5,0,"Greco, El (Domenikos Theotokopoulos)"
-29.100.53,0,"Manet, Édouard"
-29.100.565,0,"Corot, Camille"
-29.100.57,0,"Courbet, Gustave"
-29.100.6,0,"Greco, El (Domenikos Theotokopoulos)"
-29.100.66,0,"Cézanne, Paul"
+29.100.200,0,Honoré Daumier
+29.100.23,0,Jean Auguste Dominique Ingres
+29.100.370,0,Edgar Degas
+29.100.370,1,A. A. Hébrard
+29.100.5,0,El Greco (Domenikos Theotokopoulos)
+29.100.53,0,Édouard Manet
+29.100.565,0,Camille Corot
+29.100.57,0,Gustave Courbet
+29.100.6,0,El Greco (Domenikos Theotokopoulos)
+29.100.66,0,Paul Cézanne
 29.100.939,0,Rembrandt (Rembrandt van Rijn)
 29.107.28,0,Rembrandt (Rembrandt van Rijn)
-3.3,0,"Delacroix, Eugène"
-30.5,0,"La Farge, John"
-31.109,0,"Copley, John Singleton"
+3.3,0,Eugène Delacroix
+30.5,0,John La Farge
+31.109,0,John Singleton Copley
 31.11.10,0,Amasis Painter
 31.11.11,0,Lydos
 31.11.13,0,Eretria Painter
 31.11.5,0,Epimenes
-31.45,0,"David, Jacques Louis"
-31.62,0,"Hopper, Edward"
+31.45,0,Jacques Louis David
+31.62,0,Edward Hopper
 32.100.43,0,Rogier van der Weyden
-32.12,0,Rose Joseph
-32.12,1,Gilbert John
+32.12,0,Joseph Rose
+32.12,1,John Gilbert
 32.12,2,John Devall & Co.
-32.12,3,"Adam, Robert"
-32.130.2,0,"Mantegna, Andrea"
-32.130.6a–y,0,"Halder, Jacob"
-33.120.221,0,"Winslow, Edward"
-33.164a–x,0,"Lochner, Kunz"
-33.165.1,0,"Germain, François Thomas"
-33.23,0,de Werve Claus
-33.43.132,0,"Käsebier, Gertrude"
-33.43.303,0,"White, Clarence H."
-33.43.334,0,"Strand, Paul"
-33.43.343,0,"Sheeler, Charles"
-33.43.36,0,"Steichen, Edward J."
-33.43.39,0,"Steichen, Edward J."
-33.43.43,0,"Steichen, Edward J."
-33.43.44,0,"Steichen, Edward J."
-33.43.47,0,"Steichen, Edward J."
-33.61,0,"Bingham, George Caleb"
-"33.65.11, .226",0,"Gardner, Alexander"
-"33.65.11, .226",1,"Brady, Mathew B."
+32.12,3,Robert Adam
+32.130.2,0,Andrea Mantegna
+32.130.6a–y,0,Jacob Halder
+33.120.221,0,Edward Winslow
+33.164a–x,0,Kunz Lochner
+33.165.1,0,François Thomas Germain
+33.23,0,Claus de Werve
+33.43.132,0,Gertrude Käsebier
+33.43.303,0,Clarence H. White
+33.43.334,0,Paul Strand
+33.43.343,0,Charles Sheeler
+33.43.36,0,Edward J. Steichen
+33.43.39,0,Edward J. Steichen
+33.43.43,0,Edward J. Steichen
+33.43.44,0,Edward J. Steichen
+33.43.47,0,Edward J. Steichen
+33.61,0,George Caleb Bingham
+"33.65.11, .226",0,Alexander Gardner
+"33.65.11, .226",1,Mathew B. Brady
 33.7,0,Abu'l Qasim Firdausi
-33.92ab,0,"Eyck, Jan van"
-34.100.124,0,"Roth, Heinrich"
-34.134,0,"La Farge, John"
-34.138,0,"Watteau, Antoine"
-34.73,0,"Ribera, Jusepe de (called Lo Spagnoletto)"
-34.86.1 a,0,"Stradivari, Antonio"
-34.86.2 a,0,"Stradivari, Antonio"
-34.92,0,"Eakins, Thomas"
-35.27,0,"Schongauer, Martin"
+33.92ab,0,Jan van Eyck
+34.100.124,0,Heinrich Roth
+34.134,0,John La Farge
+34.138,0,Antoine Watteau
+34.73,0,Jusepe de Ribera (called Lo Spagnoletto)
+34.86.1 a,0,Antonio Stradivari
+34.86.2 a,0,Antonio Stradivari
+34.92,0,Thomas Eakins
+35.27,0,Martin Schongauer
 35.42,0,Goya (Francisco de Goya y Lucientes)
 "36.120.417a, b, .418a–c",0,Sukemitsu of Bizen
 "36.120.417a, b, .418a–c",1,Yasumitsu
 "36.120.417a, b, .418a–c",2,Iwamoto Konkan
 36.120.79,0,Ishiguro Masayoshi
-36.14a–c,0,"Patinir, Joachim"
-36.37 (25),0,"Talbot, William Henry Fox"
-37.165.107,0,"Watteau, Antoine"
-37.45.3(27),0,"Piranesi, Giovanni Battista"
-37.45.3(27),1,"Bouchard, Giovanni"
-38.34,0,"Southworth, Albert Sands"
-38.34,1,"Hawes, Josiah Johnson"
+36.14a–c,0,Joachim Patinir
+36.37 (25),0,William Henry Fox Talbot
+37.165.107,0,Antoine Watteau
+37.45.3(27),0,Giovanni Battista Piranesi
+37.45.3(27),1,Giovanni Bouchard
+38.34,0,Albert Sands Southworth
+38.34,1,Josiah Johnson Hawes
 38.34,2,Southworth and Hawes
-38.59,0,"Furman, Warner Williams Sarah"
-38.63,0,"Kierstede, Cornelius"
-39.121a–n,0,"Cousin, Jean, the Elder"
-39.121a–n,1,"Delaune, Étienne"
-39.121a–n,2,"Pellerin, Baptiste"
-39.153,0,"Maiano, Giuliano da"
+38.59,0,Sarah Furman Warner Williams
+38.63,0,Cornelius Kierstede
+39.121a–n,0,Jean Cousin the Elder
+39.121a–n,1,Étienne Delaune
+39.121a–n,2,Baptiste Pellerin
+39.153,0,Giuliano da Maiano
 39.153,1,Francesco di Giorgio Martini
 39.153,3,Benedetto da Maiano
-39.52,0,"Peale, James"
-39.65.53,0,"Saint-Gaudens, Augustus"
-39.68.27,0,"Lucas, David"
-39.68.27,1,"Constable, John"
+39.52,0,James Peale
+39.65.53,0,Augustus Saint-Gaudens
+39.68.27,0,David Lucas
+39.68.27,1,John Constable
 41.1.31,0,Rembrandt (Rembrandt van Rijn)
-41.100.132,0,de Liège Jean
-41.100.23,0,"Martini, Simone"
+41.100.132,0,Jean de Liège
+41.100.23,0,Simone Martini
 41.138,0,Unidentified Artist
-41.82,0,"Roentgen, David"
-41.82,1,"Zick, Januarius"
-41.82,2,"Chippendale, Thomas"
-42.154,0,"Curry, John Steuart"
-42.155,0,"Blume, Peter"
-42.167,0,"Lawrence, Jacob"
-42.22,0,"Kuntz, Jacob"
-42.50.16,0,"Treviso, Girolamo da"
+41.82,0,David Roentgen
+41.82,1,Januarius Zick
+41.82,2,Thomas Chippendale
+42.154,0,John Steuart Curry
+42.155,0,Peter Blume
+42.167,0,Jacob Lawrence
+42.22,0,Jacob Kuntz
+42.50.16,0,Girolamo da Treviso
 42.50.2,0,LIONARDO
-43.106.1,0,"Dürer, Albrecht"
-43.13,0,"Murillo, Bartolomé Estebán"
-43.159.1,0,"Benton, Thomas Hart"
-43.86.4,0,"Copley, John Singleton"
-43.87.17,0,"Eakins, Thomas"
-43.87.23,0,"Eakins, Thomas"
+43.106.1,0,Albrecht Dürer
+43.13,0,Bartolomé Estebán Murillo
+43.159.1,0,Thomas Hart Benton
+43.86.4,0,John Singleton Copley
+43.87.17,0,Thomas Eakins
+43.87.23,0,Thomas Eakins
 "44.21a, b",0,Clodion (Claude Michel)
-45.128.5,0,Pesquera Diego de
-45.62.1,0,"Morse, Samuel F. B."
-"46.140.767a, b",0,Boston and Sandwich Glass Company
-46.16,0,"Poussin, Nicolas"
-46.192.4,0,"Smith, John Rubens"
-46.25.1a–d,0,"Worth, Charles Frederick"
-46.25.1a–d,1,"Worth, House of"
-46.43.4,0,"Le Brun, Charles"
-46.43.4,1,Lemoyen le Lorrain Jean
+45.128.5,0,Diego de Pesquera
+45.62.1,0,Samuel F. B. Morse
+"46.140.767a, b",0,Boston & Sandwich Glass Company
+46.16,0,Nicolas Poussin
+46.192.4,0,John Rubens Smith
+46.25.1a–d,0,Charles Frederick Worth
+46.25.1a–d,1,House of Worth
+46.43.4,0,Charles Le Brun
+46.43.4,1,Jean Lemoyen le Lorrain
 46.43.4,2,"Convent of Saint Joseph-de-la-Providence, Paris"
-46.43.4,3,Montespan Marquise de
-47.106,0,"Picasso, Pablo"
-47.26,0,"Burne-Jones, Edward, Sir"
-48.190.2,0,"Gogh, Vincent van"
-48.81,0,"Miller, Sally"
-49.12,0,"Copley, John Singleton"
-49.24,0,"Chardin, Jean Siméon"
-49.3,0,"Gogh, Vincent van"
-49.38,0,"Fouquet, Jean"
-49.55.327,0,"de Meyer, Adolf"
-49.55.35,0,"Stieglitz, Alfred"
-49.59.1,0,"Demuth, Charles"
-49.7.10,0,"Lippi, Filippino"
-49.7.108,0,LIMOSIN LÉONARD
+46.43.4,3,Marquise de Montespan
+47.106,0,Pablo Picasso
+47.26,0,Sir Edward Burne-Jones
+48.190.2,0,Vincent van Gogh
+48.81,0,Sally Miller
+49.12,0,John Singleton Copley
+49.24,0,Jean Siméon Chardin
+49.3,0,Vincent van Gogh
+49.38,0,Jean Fouquet
+49.55.327,0,Adolf de Meyer
+49.55.35,0,Alfred Stieglitz
+49.59.1,0,Charles Demuth
+49.7.10,0,Filippino Lippi
+49.7.108,0,Léonard Limosin
 49.7.16,0,Titian (Tiziano Vecellio)
-49.7.19,0,"Christus, Petrus"
-49.7.21,0,"David, Gerard"
+49.7.19,0,Petrus Christus
+49.7.21,0,Gerard David
 49.7.41,0,Goya (Francisco de Goya y Lucientes)
-49.7.49,0,"Fragonard, Jean Honoré"
-49.70.1,0,"Kandinsky, Vasily"
-49.70.105,0,"Marin, John"
-49.70.42,0,"Hartley, Marsden"
-50.102.4,0,"Soudbinine, Séraphin"
-50.102.4,1,"Dunand, Jean"
+49.7.49,0,Jean Honoré Fragonard
+49.70.1,0,Vasily Kandinsky
+49.70.105,0,John Marin
+49.70.42,0,Marsden Hartley
+50.102.4,0,Séraphin Soudbinine
+50.102.4,1,Jean Dunand
 50.11.4,0,Group of Boston 00.348
-50.117,0,"Wood, Grant"
-50.135.4,0,"Holbein, Hans, the Younger"
-50.135.5,0,"Lawrence, Thomas, Sir"
-50.145.66,0,"Houdon, Jean Antoine"
-50.145.8,0,"Constable, John"
+50.117,0,Grant Wood
+50.135.4,0,Hans Holbein the Younger
+50.135.5,0,Sir Thomas Lawrence
+50.145.66,0,Jean Antoine Houdon
+50.145.8,0,John Constable
 50.164,0,Riza-yi `Abbasi
-50.228.3,0,"Gardner, Caleb"
-50.583.4,0,"Dyck, Anthony van"
-51.112.1,0,"Cézanne, Paul"
-51.112.2,0,"Gauguin, Paul"
-51.112.5,0,"Rousseau, Henri (le Douanier)"
-51.33.2,0,"Toulouse-Lautrec, Henri de"
-51.56,0,Ja'far ibn Muhammad ibn `Ali
+50.228.3,0,Caleb Gardner
+50.583.4,0,Anthony van Dyck
+51.112.1,0,Paul Cézanne
+51.112.2,0,Paul Gauguin
+51.112.5,0,Henri Rousseau (le Douanier)
+51.33.2,0,Henri de Toulouse-Lautrec
+51.56,0,Ja`far ibn Muhammad ibn `Ali
 51.9,0,Leonardo da Vinci
-52.184,0,"Vanderlyn, John"
-52.203,0,"O'Keeffe, Georgia"
+52.184,0,John Vanderlyn
+52.203,0,Georgia O'Keeffe
 52.81,0,Caravaggio (Michelangelo Merisi)
 526 R82,0,Royal Asiatic Society
 526 R82,1,Cambridge University Press
-53.223,0,"Sax, Charles Joseph"
-53.225.52,0,"Palissy, Bernard"
-53.56.11,0,"Richters, Hendrik"
-53.87a-i,0,"Noguchi, Isamu"
-53.9,0,"Davis, Stuart"
-532 Eg961,0,"Belzoni, Giovanni Battista"
-532 L551,0,"Lepsius, Richard"
-532 L551,1,"Naville, Édouard F."
-532 L551,2,"Borchardt, Ludwig"
+53.223,0,Charles Joseph Sax
+53.225.52,0,Bernard Palissy
+53.56.11,0,Hendrik Richters
+53.87a-i,0,Isamu Noguchi
+53.9,0,Stuart Davis
+532 Eg961,0,Giovanni Battista Belzoni
+532 L551,0,Richard Lepsius
+532 L551,1,Édouard F. Naville
+532 L551,2,Ludwig Borchardt
 "54.1.1a, b",0,The Limbourg Brothers
-54.1.2,0,PUCELLE JEAN
-54.167,0,"Myers, Myer"
-543.1N48 M97 Q,0,Curtius Ernst
-543.1N48 M97 Q,1,"Cesnola, Luigi Palma di"
+54.1.2,0,Jean Pucelle
+54.167,0,Myer Myers
+543.1N48 M97 Q,0,Ernst Curtius
+543.1N48 M97 Q,1,Luigi Palma di Cesnola
 55.119,0,Claude Lorrain (Claude Gellée)
 55.121.10.22,0,Govardhan
 55.121.10.22,1,Mir 'Ali Haravi
 55.121.10.24,0,Chitarman
-55.44,0,"Ibn al-Suhrawardi al-Bakri, Ahmad"
+55.44,0,Ahmad ibn al-Suhrawardi al-Bakri
 55.44,1,Muhammad ibn Aibak ibn 'Abdallah
-55.86 a-c,0,"Stradivari, Antonio"
-55.93,0,"Antico (Alari Bonacolsi, Pier Jacopo)"
+55.86 a-c,0,Antonio Stradivari
+55.93,0,Antico (Pier Jacopo Alari Bonacolsi)
 551 G41,0,"Apvd Gvlielmvm, svb scvto veneto"
-551 G41,1,"Gilles, Pierre"
-56.105,0,"Pajou, Augustin"
+551 G41,1,Pierre Gilles
+56.105,0,Augustin Pajou
 56.11.1,0,Amasis Painter
 56.171.38,0,Berlin Painter
 56.171.64,0,Lycurgus Painter
-56.205.1,0,"Gorky, Arshile"
-56.228,0,"Brugghen, Hendrick ter"
-56.70a–c,0,"Campin, Robert"
-57.130.7,0,"Belter, J. H."
+56.205.1,0,Arshile Gorky
+56.228,0,Hendrick ter Brugghen
+56.70a–c,0,Robert Campin
+57.130.7,0,John H. Belter
 57.51.21,0,'Abdullah ibn al-Fadl
 57.51.23,0,Badi' al-Zaman ibn al-Razzaz al-Jazari
 57.51.23,1,Farrukh ibn `Abd al-Latif
 57.51.26,0,Shah Quli
-57.92,0,"Pollock, Jackson"
-58.57a–d,0,"Vignola, Jacopo [Giacomo] Barozzi da"
-58.57a–d,1,"Porta, Guglielmo della"
-58.57a–d,2,Mynardo Giovanni
-58.75.1–.22,0,Rose Joseph
-58.75.1–.22,1,"Boucher, François"
+57.92,0,Jackson Pollock
+58.57a–d,0,Jacopo [Giacomo] Barozzi da Vignola
+58.57a–d,1,Guglielmo della Porta
+58.57a–d,2,Giovanni Mynardo (Jean Ménard)
+58.75.1–.22,0,Joseph Rose
+58.75.1–.22,1,François Boucher
 58.75.1–.22,2,Manufacture Nationale des Gobelins
-58.75.1–.22,3,"Jacques, Maurice"
-58.75.1–.22,4,"Tessier, Louis"
-58.75.1–.22,5,Mayhew John
-58.75.1–.22,6,Ince William
-58.75.1–.22,7,"Neilson, Jacques"
-58.75.1–.22,8,"Soufflot, Jacques Germain"
-58.75.1–.22,9,"Wilton, Joseph"
-58.75.1–.22,10,Wildsmith John
-58.75.1–.22,11,Blockley Thomas
-58.75.1–.22,12,"Alken, Sefferin"
-58.75.1–.22,13,Langlois Peter
-58.75.1–.22,14,"Hobcraft, John"
+58.75.1–.22,3,Maurice Jacques
+58.75.1–.22,4,Louis Tessier
+58.75.1–.22,5,John Mayhew
+58.75.1–.22,6,William Ince
+58.75.1–.22,7,Jacques Neilson
+58.75.1–.22,8,Jacques Germain Soufflot
+58.75.1–.22,9,Joseph Wilton
+58.75.1–.22,10,John Wildsmith
+58.75.1–.22,11,Thomas Blockley
+58.75.1–.22,12,Sefferin Alken
+58.75.1–.22,13,Peter Langlois
+58.75.1–.22,14,John Hobcraft
 58.75.1–.22,15,Ince and Mayhew
-58.75.1–.22,16,"Adam, Robert"
-58.75.25,0,Baudoin Joseph-François-Xavier
-58.75.25,1,"Jacob, Georges"
-58.75.88a–c,0,"Dodin, Charles Nicolas"
-58.75.88a–c,1,"Duplessis, Jean-Claude"
+58.75.1–.22,16,Robert Adam
+58.75.25,0,Joseph-François-Xavier Baudoin
+58.75.25,1,Georges Jacob
+58.75.88a–c,0,Charles Nicolas Dodin
+58.75.88a–c,1,Jean-Claude Duplessis
 58.75.88a–c,2,Sèvres Manufactory
-58.89,0,"Steen, Jan"
-59.12,0,"Turner, Joseph Mallord William"
-59.166,0,"Peale, Raphaelle"
-59.76,0,"Blake, George Henry"
+58.89,0,Jan Steen
+59.12,0,Joseph Mallord William Turner
+59.166,0,Raphaelle Peale
+59.76,0,George Henry Blake
 59.76,1,Érard
-6.1234,0,"Homer, Winslow"
-6.1312,0,Nunns Robert
-6.1312,1,Clark John
-6.306,0,"Vonnoh, Bessie Potter"
+6.1234,0,Winslow Homer
+6.1312,0,Robert Nunns
+6.1312,1,John Clark
+6.306,0,Bessie Potter Vonnoh
 6.311,0,Kephisodotos
-"60.29.1a, b",0,"Fisher, Robert"
-60.3,0,"La Tour, Georges de"
-60.4.1,0,"Phyfe, Duncan"
-60.87,0,"Picasso, Pablo"
-61.101.1,0,"Cézanne, Paul"
-61.101.16,0,"Seurat, Georges"
-61.101.17,0,"Seurat, Georges"
+"60.29.1a, b",0,Robert Fisher
+60.3,0,Georges de La Tour
+60.4.1,0,Duncan Phyfe
+60.87,0,Pablo Picasso
+61.101.1,0,Paul Cézanne
+61.101.16,0,Georges Seurat
+61.101.17,0,Georges Seurat
 61.198,0,Rembrandt (Rembrandt van Rijn)
 61.200.1,0,Master of the Codex of Saint George
-62.126,0,"Castiglione, Giovanni Benedetto (Il Grechetto)"
-62.16,0,"McIntire, Samuel"
-62.189,0,Workshop of Biduinus
-62.256.3,0,"Hicks, Edward"
-62.55,0,"Houdon, Jean Antoine"
-62.79.1,0,"Smibert, John"
-62.79.2,0,"Smibert, John"
-62.95,0,"Hopper, Edward"
-62.96,0,de Touyl Jean
-63.1,0,"David, Jacques Louis"
+62.126,0,Giovanni Benedetto Castiglione (Il Grechetto)
+62.16,0,Samuel McIntire
+62.189,0,Biduinus
+62.256.3,0,Edward Hicks
+62.55,0,Jean Antoine Houdon
+62.79.1,0,John Smibert
+62.79.2,0,John Smibert
+62.95,0,Edward Hopper
+62.96,0,Jean de Touyl
+63.1,0,Jacques Louis David
 63.11.6,0,Andokides
 63.11.6,1,Andokides Painter
 63.11.6,2,Lysippides Painter
 63.178.1,0,Muslim Ibn al-Dahhan
-63.201.1,0,"Hathaway, Rufus"
+63.201.1,0,Rufus Hathaway
 63.210.11,0,Farid al-Din `Attar
-63.210.11,1,Habiballah
+63.210.11,1,Habiballah of Sava
 63.350.246.206.378,0,American Tobacco Company
-63.4,0,Martínez Montañés Juan
-63.73,0,"Kelly, Ellsworth"
-64.148,0,"Klimt, Gustav"
-64.79,0,Cobb John
-64.79,1,"Vile, William"
-65.167.6,0,"Finlay, John"
-65.167.6,1,"Finlay, Hugh"
-65.247,0,"Motherwell, Robert"
+63.4,0,Juan Martínez Montañés
+63.73,0,Ellsworth Kelly
+64.148,0,Gustav Klimt
+64.79,0,John Cobb
+64.79,1,William Vile
+65.167.6,0,John Finlay
+65.167.6,1,Hugh Finlay
+65.247,0,Robert Motherwell
 65.47,0,"Imperial Porcelain Manufactory, St. Petersburg"
-65.49,0,"Beaux, Cecilia"
-66.113,0,"Cropsey, Jasper Francis"
-66.126,0,"Mount, William Sidney"
-66.143,0,"La Farge, John"
-66.244.1-.25,0,"Lévy-Dhurmer, Lucien"
-67.110.1,0,"Canova, Antonio"
-67.110.1,1,Tarnowski Jan and Valeria Count and Countess
-67.187.121,0,"Bellows, George"
-67.187.123,0,"Chase, William Merritt"
-67.187.53a-c,0,"Beckmann, Max"
-67.197,0,Lemoyne Jean-Louis
-67.232,0,"Louis, Morris"
-67.241,0,"Monet, Claude"
-67.25,0,"Carpeaux, Jean-Baptiste"
+65.49,0,Cecilia Beaux
+66.113,0,Jasper Francis Cropsey
+66.126,0,William Sidney Mount
+66.143,0,John La Farge
+66.244.1-.25,0,Lucien Lévy-Dhurmer
+67.110.1,0,Antonio Canova
+67.110.1,1,Count Jan and Countess Valeria Tarnowski
+67.187.121,0,George Bellows
+67.187.123,0,William Merritt Chase
+67.187.53a-c,0,Max Beckmann
+67.197,0,Jean-Louis Lemoyne
+67.232,0,Morris Louis
+67.241,0,Claude Monet
+67.25,0,Jean-Baptiste Carpeaux
 67.855,0,"Aetna Silkscreen Products, Inc."
 67.855,1,Du-Art Displays
-67.855,2,"Warhol, Andy"
+67.855,2,Andy Warhol
 67.855,3,Factory Additions
-68.1,0,"Bonnard, Pierre"
-68.100.1,0,"Roux, Alexander"
-68.141.81a–f,0,Pantin Simon I
+68.1,0,Pierre Bonnard
+68.100.1,0,Alexander Roux
+68.141.81a–f,0,Simon Pantin I
 68.148,0,Bastis Master
-68.185,0,"Graham, John"
-69.113,0,"Robbia, Andrea della"
+68.185,0,John Graham
+69.113,0,Andrea della Robbia
 "69.140a, b",0,Herter Brothers
 69.27,0,Hatifi
 69.27,1,Suzi
-69.88,0,"Siloe, Gil de"
-7.122,0,"Renoir, Auguste"
-7.123,0,"Bierstadt, Albert"
-7.16,0,"Stuart, Gilbert"
-7.79,0,"Remington, Frederic"
-72.3,0,"Powers, Hiram"
-74.24,0,"Kensett, John Frederick"
+69.88,0,Gil de Siloe
+7.122,0,Auguste Renoir
+7.123,0,Albert Bierstadt
+7.16,0,Gilbert Stuart
+7.79,0,Frederic Remington
+72.3,0,Hiram Powers
+74.24,0,John Frederick Kensett
 75.7.2,0,Piero di Cosimo (Piero di Lorenzo di Piero d'Antonio)
-"77.9a, b",0,"Whitehouse, James Horton"
+"77.9a, b",0,James Horton Whitehouse
 "77.9a, b",1,Tiffany & Co.
-"77.9a, b",2,"Soligny, Eugene J."
-"77.9a, b",3,"Saint-Gaudens, Augustus"
-8.228,0,"Cole, Thomas"
-80.1.2,0,"Richards, William Trost"
-87.25,0,"Bonheur, Rosa"
-87.8.8,0,"Inness, George"
-88.5a–d,0,"Story, William Wetmore"
-89.15.19,0,"Lippi, Fra Filippo"
-89.15.21,0,"Vermeer, Johannes"
-89.21.1,0,"Bastien-Lepage, Jules"
-89.4.1097,0,"Naeplaesnigg, Andreas"
-89.4.1191,0,"Hauslaib, Lorenz"
-89.4.1191,1,"Cuntz, Steffan"
-89.4.1196,0,Grouwels Lodewijck
-89.4.1219,0,Cristofori Bartolomeo
-89.4.1236,0,Hayashi Kodenji
+"77.9a, b",2,Eugene J. Soligny
+"77.9a, b",3,Augustus Saint-Gaudens
+8.228,0,Thomas Cole
+80.1.2,0,William Trost Richards
+87.25,0,Rosa Bonheur
+87.8.8,0,George Inness
+88.5a–d,0,William Wetmore Story
+89.15.19,0,Fra Filippo Lippi
+89.15.21,0,Johannes Vermeer
+89.21.1,0,Jules Bastien-Lepage
+89.4.1097,0,Andreas Naeplaesnigg
+89.4.1191,0,Lorenz Hauslaib
+89.4.1191,1,Steffan Cuntz
+89.4.1196,0,Lodewijck Grouwels
+89.4.1219,0,Bartolomeo Cristofori
+89.4.1236,0,Kodenji Hayashi
 89.4.2058,0,Sioux
-89.4.2375,0,Haas Johann Wilhelm
+89.4.2375,0,Johann Wilhelm Haas
 "89.4.2631 a, b",0,Athabascan Family
-"89.4.28 a, b",0,Elevated Tone Workshop
-89.4.2883,0,"Voll, Georg"
-89.4.2929a–e,0,"Todini, Michele"
-89.4.2929a–e,1,"Onofri, Basilio"
-89.4.2929a–e,2,"Reiff, Jacob"
-89.4.909,0,"Gahn, Johann Benedikt"
-89.4.912,0,"Boekhout, Thomas Coenraet"
+"89.4.28 a, b",0,"Elevated Tone Workshop, Guangzhou (Canton)"
+89.4.2883,0,Georg Voll
+89.4.2929a–e,0,Michele Todini
+89.4.2929a–e,1,Basilio Onofri
+89.4.2929a–e,2,Jacob Reiff
+89.4.909,0,Johann Benedikt Gahn
+89.4.912,0,Thomas Coenraet Boekhout
 89.4.924,0,Claude Laurent
 89.4.926,0,Ganda
-9.95,0,"Church, Frederic Edwin"
-903.6 R541 F,0,"Haghe, Louis"
-903.6 R541 F,1,Croly George Rev.
-903.6 R541 F,2,"Roberts, David"
+9.95,0,Frederic Edwin Church
+903.6 R541 F,0,Louis Haghe
+903.6 R541 F,1,Rev. George Croly
+903.6 R541 F,2,David Roberts
 91.1.535a–h,0,‘Umar ibn Yusuf ibn ‘Umar ibn ‘Ali ibn Rasul al-Muzaffari
-911.1. M362,0,Martinellie Domenico
-912.1 K63 Q,0,Kirchner Athanasius
-912.63 D23,0,"Dapper, Olfert"
-916.3 An4 F,0,Angas George French
-920.3 W52 F,0,"Westmacott, Richard, Sir"
-920.84 M292,0,Malory Thomas Sir
-920.84 M292,1,"Beardsley, Aubrey Vincent"
-926.1 M642,0,"Milton, John"
-94.14,0,"Powers, Hiram"
-94.4.172,0,"Wedgwood and Sons, Josiah"
-94.9.3,0,"Palmer, Erastus Dow"
-959.9 M292,0,Malthus Francis
-96.17.10,0,"Tiffany, Louis Comfort"
+911.1. M362,0,Domenico Martinelli
+912.1 K63 Q,0,Athanasius Kircher
+912.63 D23,0,Olfert Dapper
+916.3 An4 F,0,George French Angas
+920.3 W52 F,0,Sir Richard Westmacott
+920.84 M292,0,Sir Thomas Malory
+920.84 M292,1,Aubrey Vincent Beardsley
+926.1 M642,0,John Milton
+94.14,0,Hiram Powers
+94.4.172,0,Josiah Wedgwood and Sons
+94.9.3,0,Erastus Dow Palmer
+959.9 M292,0,Francis Malthus
+96.17.10,0,Louis Comfort Tiffany
 96.17.10,1,Tiffany Glass and Decorating Company
-96.29,0,"Turner, Joseph Mallord William"
-97.13.1,0,"Crawford, Thomas"
-97.19,0,"MacMonnies, Frederick William"
-97.29.3,0,"Pratt, Matthew"
-97.33,0,"Peale, Charles Willson"
-97.34,0,"Leutze, Emanuel"
+96.29,0,Joseph Mallord William Turner
+97.13.1,0,Thomas Crawford
+97.19,0,Frederick William MacMonnies
+97.29.3,0,Matthew Pratt
+97.33,0,Charles Willson Peale
+97.34,0,Emanuel Leutze
 99.2,0,Tiffany & Co.
-99.2,1,"Curran, John T."
-99.31,0,"Turner, Joseph Mallord William"
+99.2,1,John T. Curran
+99.31,0,Joseph Mallord William Turner
 AE25 .E53 1751 Q,0,Briasson
-AE25 .E53 1751 Q,1,"Diderot, Denis"
-AE25 .E53 1751 Q,2,"Alembert, Jean Le Rond d'"
-AE25 .E531 1762 Q,0,"Mouchon, Pierre"
+AE25 .E53 1751 Q,1,Denis Diderot
+AE25 .E53 1751 Q,2,Jean Le Rond d'Alembert
+AE25 .E531 1762 Q,0,Pierre Mouchon
 AE25 .E531 1762 Q,1,Briasson
-AE25 .E531 1762 Q,2,"Alembert, Jean Le Rond d'"
-AE25 .E531 1762 Q,3,"Diderot, Denis"
-AE25 .E532 1758 Q,0,"Diodati, Ottaviano"
-AE25 .E532 1758 Q,1,"Giuntini, Vincenzo"
-AE25 .E532 1758 Q,2,"Alembert, Jean Le Rond d'"
-AE25 .E532 1758 Q,3,"Diderot, Denis"
-AE25 .E533 1765 Q,0,"Giuntini, Vincenzo"
-AE25 .E533 1765 Q,1,"Diderot, Denis"
-AY831 .Z7 1783,0,"Houry, Laurent Charles d'"
-AY831 .Z7 1784,0,"Hérissant, La Veuve"
-AY831 .Z7 1784,1,"Collombat, Jacques"
-AY831 .Z7 1784a,0,"Houry, Laurent Charles d'"
-AY831 .Z7 1788,0,"Houry, Laurent Charles d'"
-AY831 .Z7 1792,0,"Houry, Laurent Charles d'"
+AE25 .E531 1762 Q,2,Jean Le Rond d'Alembert
+AE25 .E531 1762 Q,3,Denis Diderot
+AE25 .E532 1758 Q,0,Ottaviano Diodati
+AE25 .E532 1758 Q,1,Vincenzo Giuntini
+AE25 .E532 1758 Q,2,Jean Le Rond d'Alembert
+AE25 .E532 1758 Q,3,Denis Diderot
+AE25 .E533 1765 Q,0,Vincenzo Giuntini
+AE25 .E533 1765 Q,1,Denis Diderot
+AY831 .Z7 1783,0,Laurent Charles d' Houry
+AY831 .Z7 1784,0,La Veuve Hérissant
+AY831 .Z7 1784,1,Jacques Collombat
+AY831 .Z7 1784a,0,Laurent Charles d' Houry
+AY831 .Z7 1788,0,Laurent Charles d' Houry
+AY831 .Z7 1792,0,Laurent Charles d' Houry
 AY831 .Z7 1792,1,Imprimerie de Testu
-BF207 .L4 1972,0,"Alpert, Richard"
-BF207 .L4 1972,1,"Metzner, Ralph"
-BF207 .L4 1972,2,"Leary, Timothy"
-BF209.M4 M5313 1963,0,"Michaux, Henri"
-BS75 1785b Q,0,"Didot, François Ambroise"
-BS75 1785b Q,1,"Gibbs, Josiah W. (Josiah Willard)"
-BV4823 .D48 1741,0,"Humblot, Antoine"
-BV4823 .D48 1741,1,"Guélard, J. B."
-BV4823 .D48 1741,2,"Duflos, Claude"
-BV4834 .A75 1696,0,Arndts Johan
-BX2010 .A2 1794,0,"Mazzinelli, Alessandro"
-BX2010 .A2 1794,1,"Pacetti, Giovanni Battista"
+BF207 .L4 1972,0,Richard Alpert
+BF207 .L4 1972,1,Ralph Metzner
+BF207 .L4 1972,2,Timothy Leary
+BF209.M4 M5313 1963,0,Henri Michaux
+BS75 1785b Q,0,François Ambroise Didot
+BS75 1785b Q,1,Josiah W. (Josiah Willard) Gibbs
+BV4823 .D48 1741,0,Antoine Humblot
+BV4823 .D48 1741,1,J. B. Guélard
+BV4823 .D48 1741,2,Claude Duflos
+BV4834 .A75 1696,0,Johan Arndts
+BX2010 .A2 1794,0,Alessandro Mazzinelli
+BX2010 .A2 1794,1,Giovanni Battista Pacetti
 BX2010 .A2 1794,2,Catholic Church
-BX2010 .A2 1794,3,"Passeri, Giuseppe"
-BX2010 .A2 1794,4,"Carracci, Annibale"
-BX2010 .A2 1794,5,Salvioni
+BX2010 .A2 1794,3,Giuseppe Passeri (Passari)
+BX2010 .A2 1794,4,Annibale Carracci
+BX2010 .A2 1794,5,Luigi Perego Salvioni
 BX2016.A5 F7 1792,0,Catholic Church
 BX2016.A5 F7 1792,1,Langlois
 BX9454 .S25 1688,0,Arnold Seneuse
 BX9454 .S25 1688,1,Denis de Sainte-Marthe
-C.I.42.33.3,0,"Molyneux, Edward"
-C.I.44.64.8a–c,0,"Chanel, Gabrielle ""Coco"""
-C.I.44.64.8a–c,1,"Chanel, House of"
+C.I.42.33.3,0,Edward Molyneux
+C.I.44.64.8a–c,0,"Gabrielle ""Coco"" Chanel"
+C.I.44.64.8a–c,1,House of Chanel
 "C.I.45.27a, b",0,Maison Léoty
-"C.I.46.4.18a, b",0,"Lanvin, Jeanne"
-"C.I.46.4.18a, b",1,"Lanvin, House of"
-C.I.46.4.20a–c,0,"Worth, House of"
-"C.I.46.57a, b",0,Rosenstein Nettie
+"C.I.46.4.18a, b",0,Jeanne Lanvin
+"C.I.46.4.18a, b",1,House of Lanvin
+C.I.46.4.20a–c,0,House of Worth
+"C.I.46.57a, b",0,Nettie Rosenstein
 C.I.50.110a–j,0,Mainbocher
-C.I.50.44,0,"Fortuny, Mariano"
+C.I.50.44,0,Mariano Fortuny
 C.I.50.44,1,Fortuny
-C.I.51.83,0,Schiaparelli Elsa
-C.I.52.18.4,0,"Vionnet, Madeleine"
-C.I.52.5.2,0,Reboux Caroline
-C.I.53.40.7a–e,0,"Dior, Christian"
-C.I.53.40.7a–e,1,"Dior, House of"
-C.I.53.73,0,James Charles
-"C.I.54.16.1a, b",0,"Chanel, Gabrielle ""Coco"""
-"C.I.54.16.1a, b",1,"Chanel, House of"
+C.I.51.83,0,Elsa Schiaparelli
+C.I.52.18.4,0,Madeleine Vionnet
+C.I.52.5.2,0,Caroline Reboux
+C.I.53.40.7a–e,0,Christian Dior
+C.I.53.40.7a–e,1,House of Dior
+C.I.53.73,0,Charles James
+"C.I.54.16.1a, b",0,"Gabrielle ""Coco"" Chanel"
+"C.I.54.16.1a, b",1,House of Chanel
 C.I.57.17.3,0,Weeks
-"C.I.58.13.6a, b",0,"Balenciaga, Cristobal"
-"C.I.58.13.6a, b",1,Balenciaga House of
-C.I.58.25a–c,0,"Adrian, Gilbert"
-C.I.58.34.30,0,"Dior, Christian"
-C.I.58.34.30,1,"Dior, House of"
-"C.I.58.49.4a, b",0,McCardell Claire
-"C.I.58.49.4a, b",1,Townley
-"C.I.60.21.1a, b",0,"Dior, Christian"
-"C.I.60.21.1a, b",1,"Dior, House of"
-C.I.61.40.4,0,"Poiret, Paul"
-C.I.66.14.2,0,"Garthwaite, Anna Maria"
-C.I.66.14.2,1,Lekeux Peter
-C.I.68.53.5a–h,0,Rossberg Herman
-C.I.69.23,0,Saint Laurent Yves
-C.I.69.23,1,"Saint Laurent Yves, Paris"
-C.I.X.56.2.1,0,Paquin House of
-C.I.X.56.2.1,1,Paquin Jeanne
-DA447.G7 H26 1876,0,"Hamilton, Anthony, Count"
-DA447.G7 H26 1876,1,"Chauvet, Jules Adolphe"
-DA447.G7 H26 1876,2,"Lamire, Leon"
+"C.I.58.13.6a, b",0,Cristobal Balenciaga
+"C.I.58.13.6a, b",1,House of Balenciaga
+C.I.58.25a–c,0,Gilbert Adrian
+C.I.58.34.30,0,Christian Dior
+C.I.58.34.30,1,House of Dior
+"C.I.58.49.4a, b",0,Claire McCardell
+"C.I.58.49.4a, b",1,Townley Frocks
+"C.I.60.21.1a, b",0,Christian Dior
+"C.I.60.21.1a, b",1,House of Dior
+C.I.61.40.4,0,Paul Poiret
+C.I.66.14.2,0,Anna Maria Garthwaite
+C.I.66.14.2,1,Peter Lekeux
+C.I.68.53.5a–h,0,Herman Rossberg
+C.I.69.23,0,Yves Saint Laurent
+C.I.69.23,1,"Yves Saint Laurent, Paris"
+C.I.X.56.2.1,0,House of Paquin
+C.I.X.56.2.1,1,Mme. Jeanne Paquin
+DA447.G7 H26 1876,0,Count Anthony Hamilton
+DA447.G7 H26 1876,1,Jules Adolphe Chauvet
+DA447.G7 H26 1876,2,Leon Lamire
 DA447.G7 H26 1876,3,Marius Michel et fils
-DC122.8 .P413 1785,0,"Le Moine, L. H."
-DC122.8 .P413 1785,1,de Perefixe Hardouin
-DC130.L14 L14 1749,0,"Auguste, Charles, marquis de La Fare"
+DC122.8 .P413 1785,0,L. H. Le Moine
+DC122.8 .P413 1785,1,Hardouin de Perefixe
+DC130.L14 L14 1749,0,"Charles Auguste, marquis de La Fare"
 DC611.N846 A5 1788,0,La Veuve Besongne & Fils
-DH188.H67 W47 1568,0,"Wesenbeke, Jacques de"
+DH188.H67 W47 1568,0,Jacques de Wesenbeke
 F595 .R38 1895,0,Harper & Brothers
-F595 .R38 1895,1,"Remington, Frederic"
+F595 .R38 1895,1,Frederic Remington
 G150 .A45 1820,0,Marcilly
-GB1321 .M68 1766,0,"Moura Portugal, Bento de"
-GT2050 .U813 1884,0,"Avril, Paul"
-GT2050 .U813 1884,1,"Nimmo, J. C. and Bain"
-GT2050 .U813 1884,2,"Uzanne, Octave"
-GV1801 .L6 1889,0,Le Roux Hugues
-GV1801 .L6 1889,1,"Garnier, Jules"
-GV1801 .L6 1889,2,"Plon E., Nourrit et Cie."
-KKL273.1.Z94 C4 1815,0,"Lodigiani, Luigi"
-"L.2009.22.279a, b",0,"Ohr, George E."
+GB1321 .M68 1766,0,Bento de Moura Portugal
+GT2050 .U813 1884,0,Paul Avril
+GT2050 .U813 1884,1,J. C. Nimmo and Bain
+GT2050 .U813 1884,2,Octave Uzanne
+GV1801 .L6 1889,0,Hugues Le Roux
+GV1801 .L6 1889,1,Jules Garnier
+GV1801 .L6 1889,2,"E. Plon, Nourrit et Cie."
+KKL273.1.Z94 C4 1815,0,Luigi Lodigiani
+"L.2009.22.279a, b",0,George E. Ohr
 M2149.5 .C5 1768,0,Catholic Church
 M2149.5 .C5 1768,1,Baudouin
 N6659.P32 A4 1976,0,Galeria Arte Global
-N6659.P32 A4 1976,1,"Pape, Lygia"
-N6659.P32 A4 1976,2,"Oiticica, Hélio"
-N7433.4.B76 P43 1966,0,"Broodthaers, Marcel"
+N6659.P32 A4 1976,1,Lygia Pape
+N6659.P32 A4 1976,2,Hélio Oiticica
+N7433.4.B76 P43 1966,0,Marcel Broodthaers
 N7433.4.C65 D43 2015,0,Black Stone Press
 N7433.4.C65 D43 2015,1,Heavenly Monkey
-N7433.4.C65 D43 2015,2,"Cohen, Claudia"
-N7433.4.C65 D43 2015,3,"Hodgson, Barbara"
-NC765 .A9 1683 Q,0,"Audran, Girard"
-ND3365.G7 B74 2009a Q,0,"Brotto, Carlo Bertoncello"
-ND3365.G7 B74 2009a Q,1,"Malato, Enrico"
+N7433.4.C65 D43 2015,2,Claudia Cohen
+N7433.4.C65 D43 2015,3,Barbara Hodgson
+NC765 .A9 1683 Q,0,Girard Audran
+ND3365.G7 B74 2009a Q,0,Carlo Bertoncello Brotto
+ND3365.G7 B74 2009a Q,1,Enrico Malato
 ND3365.G7 B74 2009a Q,2,Biblioteca Nazionale Marciana
 ND3365.G7 B74 2009a Q,3,Salerno Editrice
-ND616 .G35 1812,0,"Landon, Charles-Paul"
+ND616 .G35 1812,0,Charles-Paul Landon
 ND616 .G35 1812,1,Chaignieau
 ND616 .G35 1812,2,Simier
-NE2049.5.W38 W38 1710,0,"Watteau, Antoine"
-NE2049.5.W38 W38 1710,1,"Cochin, Charles Nicolas, I"
-NE2049.5.W38 W38 1710,2,"Desplaces, Louis"
-NE2049.5.W38 W38 1710,3,"Thomassin, Henri Simon"
+NE2049.5.W38 W38 1710,0,Antoine Watteau
+NE2049.5.W38 W38 1710,1,Charles Nicolas Cochin I
+NE2049.5.W38 W38 1710,2,Louis Desplaces
+NE2049.5.W38 W38 1710,3,Henri Simon Thomassin
 NE2049.5.W38 W38 1710,4,Hardy-Mennil
-NK1483 .J7 1867 Q,0,"Gilbert, S. & T."
-NK1483 .J7 1867 Q,1,"Jones, Owen"
-NK1510 .J7 1868 Q,0,"Jones, Owen"
-NK1510 .J7 1868 Q,1,"Westwood, J. O."
-NK1510 .J7 1868 Q,2,"Wyatt, Matthew Digby Sir"
+NK1483 .J7 1867 Q,0,S. & T. Gilbert
+NK1483 .J7 1867 Q,1,Owen Jones
+NK1510 .J7 1868 Q,0,Owen Jones
+NK1510 .J7 1868 Q,1,J. O. Westwood
+NK1510 .J7 1868 Q,2,Matthew Digby Wyatt
 NK1510 .J7 1868 Q,3,Bernard Quaritch Ltd.
-NK1510 .J7 1868 Q,4,"Waring, J. B."
-NK1530 .A5 1930,0,"Washburn, Ives"
-NK1530 .A5 1930,1,Glassgold A. C.
-NK1530 .A5 1930,2,"Leonard, Robert"
+NK1510 .J7 1868 Q,4,J. B. Waring
+NK1530 .A5 1930,0,Ives Washburn
+NK1530 .A5 1930,1,A. C. Glassgold
+NK1530 .A5 1930,2,Robert Leonard
 NK1530 .A5 1930,3,American Union of Decorative Artists and Craftsmen
-NK1700 .I57 Q v.1 1900,0,"Schroll, A."
-NK1700 .I57 Q v.1 1900,1,"Abels, Ludwig"
-NK1700 .I57 Q v.2 1901,0,"Schroll, A."
-NK1700 .I57 Q v.2 1901,1,"Abels, Ludwig"
-NK2229 .S54 1793,0,"Sheraton, Thomas"
-NK2229 .S54 1793,1,"Bensley, Thomas"
-NK7983.A1 W36 1752,0,"Wang, Fu"
-NX511.A88 A88 1971 Quarto,0,"Andrews, Benny"
-NX511.A88 A88 1971 Quarto,1,"Baranik, Rudolf"
+NK1700 .I57 Q v.1 1900,0,A. Schroll
+NK1700 .I57 Q v.1 1900,1,Ludwig Abels
+NK1700 .I57 Q v.2 1901,0,A. Schroll
+NK1700 .I57 Q v.2 1901,1,Ludwig Abels
+NK2229 .S54 1793,0,Thomas Sheraton
+NK2229 .S54 1793,1,Thomas Bensley
+NK7983.A1 W36 1752,0,Fu Wang
+NX511.A88 A88 1971 Quarto,0,Benny Andrews
+NX511.A88 A88 1971 Quarto,1,Rudolf Baranik
 NX511.A88 A88 1971 Quarto,2,Black Emergency Cultural Coalition and Artists and Writers Protest Against the War in Vietnam
 PA4375.M8 D3 1772,0,Plutarch
 PA4375.M8 D3 1772,1,L'Imprimerie Royale
-PA4375.M8 D3 1772,2,"La Porte du Theil, François Jean Gabriel de"
+PA4375.M8 D3 1772,2,François Jean Gabriel de La Porte du Theil
 PA6525.H4 N3 1762,0,Ovid
-PA6525.H4 N3 1762,1,"Gregori, Carlo"
+PA6525.H4 N3 1762,1,Carlo Gregori
 PA6525.H4 N3 1762,2,Durand
-PA6525.H4 N3 1762,3,"Conti, Giovan Stefano"
-PA6525.H4 N3 1762,4,"Nannini, Remigio"
-PA6555 .A2 1585,0,"Pithou, Pierre"
+PA6525.H4 N3 1762,3,Giovan Stefano Conti
+PA6525.H4 N3 1762,4,Remigio Nannini
+PA6555 .A2 1585,0,Pierre Pithou
 PA6555 .A2 1585,1,Sulpicia
 PA6555 .A2 1585,2,Persius
-PA6555 .A2 1585,3,"Estienne, Robert"
-PA6555 .A2 1585,4,"Patisson, Mamert"
-PA6555 .A2 1585,5,"Juvenal, Decimus Junius"
-PA6558 .A5 1726,0,"Lavaur, M. (Guillaume de)"
+PA6555 .A2 1585,3,Robert Estienne
+PA6555 .A2 1585,4,Mamert Patisson
+PA6555 .A2 1585,5,Decimus Junius Juvenal
+PA6558 .A5 1726,0,M. (Guillaume de) Lavaur
 PA6558 .A5 1726,1,Petronius Arbiter
-PL2693.H76 H74 1977 Quarto,0,"Wang, Shifu"
+PL2693.H76 H74 1977 Quarto,0,Shifu Wang
 PL2693.H76 H74 1977 Quarto,1,Min Qiji
-PL2693.H76 H74 1977 Quarto,2,"Dittrich, Edith"
-PN1489 .M37 1651,0,"Martin, Docteur (Louis)"
-PN1489 .M37 1651,1,"Belleau, Remy"
-PN1489 .M37 1651,2,"Joly, Robert "
-PN1489 .M37 1651,3,"Moynet, Simon"
-PN1489 .M37 1651,4,"Folengo, Theophilo"
-PN6231.P6 B63 1669,0,"Blaeu, Johannes"
-PN6231.P6 B63 1669,1,"Briani, Girolamo"
+PL2693.H76 H74 1977 Quarto,2,Edith Dittrich
+PN1489 .M37 1651,0,Docteur (Louis) Martin
+PN1489 .M37 1651,1,Remy Belleau
+PN1489 .M37 1651,2,Robert Joly
+PN1489 .M37 1651,3,Simon Moynet
+PN1489 .M37 1651,4,Theophilo Folengo
+PN6231.P6 B63 1669,0,Johannes Blaeu
+PN6231.P6 B63 1669,1,Girolamo Briani
 PN6231.P6 B63 1669,2,Simier
-PN6231.P6 B63 1669,3,"Boccalini, Traiano"
+PN6231.P6 B63 1669,3,Traiano Boccalini
 PQ1189 .M66 1765,0,Barbou
-PQ1189 .M66 1765,1,"Monnet, Jean"
-PQ1189 .M66 1765,2,"de Querlon, Anne Gabriel Meusnier"
-PQ1795 .T5 1790,0,"Fénelon, François de Salignac de La Mothe-"
-PQ1795 .T5 1790,1,"Cochin, Charles Nicolas, II"
-PQ1795 .T5 1790,2,"Moreau, Jean Michel, the Younger"
-PQ1795 .T5 1790,3,"Bozerian, Jean Claude"
-PQ1809 .A1 1795,0,"Boileau Despréaux, Nicolas"
-PQ1809 .A1 1795,1,"La Fontaine, Jean de"
-PQ1809 .A1 1795,2,"Eisen, Charles Dominique Joseph"
-PQ1809 .A1 1795,3,"Didot, Pierre l'ainé"
-PQ1821 1773,0,"Bret, M. (Antoine)"
-PQ1821 1773,1,"Lambert, Michel"
-PQ1821 1773,2,"Molière, Jean-Baptiste Poquelin"
+PQ1189 .M66 1765,1,Jean Monnet
+PQ1189 .M66 1765,2,Anne Gabriel Meusnier de Querlon
+PQ1795 .T5 1790,0,François de Salignac de La Mothe-Fénelon
+PQ1795 .T5 1790,1,Charles Nicolas Cochin II
+PQ1795 .T5 1790,2,Jean Michel Moreau the Younger
+PQ1795 .T5 1790,3,Jean Claude Bozerian
+PQ1809 .A1 1795,0,Nicolas Boileau Despréaux
+PQ1809 .A1 1795,1,Jean de La Fontaine
+PQ1809 .A1 1795,2,Charles Dominique Joseph Eisen
+PQ1809 .A1 1795,3,Pierre Didot l'ainé
+PQ1821 1773,0,M. (Antoine) Bret
+PQ1821 1773,1,Michel Lambert
+PQ1821 1773,2,Jean-Baptiste Poquelin Molière
 PQ1821 1773,3,Voltaire
-PQ1821 1773,4,"Mignard, Pierre"
-PQ1821 1773,5,"Moreau, Jean Michel, the Younger"
-PQ1821 1773,6,Compagnie des libraires associés
-PQ1954.A54 L4 1741,0,"Argens, Jean-Baptiste de Boyer, marquis d'"
+PQ1821 1773,4,Pierre Mignard 
+PQ1821 1773,5,Jean Michel Moreau the Younger
+PQ1821 1773,6,La Compagnie des libraires associés
+PQ1954.A54 L4 1741,0,"Jean Baptiste de Boyer, marquis d'Argens"
 PQ1954.A54 L4 1741,1,Pierre Paupie
-PQ2067.T28 D4 1770,0,"Thiroux d'Arconville, Marie Geneviève Charlotte Darlus"
-PQ2067.T28 D4 1770,1,"Diderot, Denis"
-PQ2067.T28 D4 1770,2,Compagnie des libraires associés
+PQ2067.T28 D4 1770,0,Marie Geneviève Charlotte Darlus Thiroux d'Arconville
+PQ2067.T28 D4 1770,1,Denis Diderot
+PQ2067.T28 D4 1770,2,La Compagnie des libraires associés
 PQ4272.F5 A34 1697,0,Kleihnans
-PQ4272.F5 A34 1697,1,"Gallet, George"
-PQ4272.F5 A34 1697,2,"Boccaccio, Giovanni"
-PQ4272.F5 A34 1697,3,"Hooghe, Romeyn de"
-PQ4567 .A2 1584,0,"Lavezzola, Alberto"
-PQ4567 .A2 1584,1,"Garofolo, Girolamo"
-PQ4567 .A2 1584,2,"Bononome, Giuseppe"
-PQ4567 .A2 1584,3,"Groto, Luigi"
-PQ4567 .A2 1584,4,"Eugenico, Niccolò"
-PQ4567 .A2 1584,5,"Ariosto, Ludovico"
-PQ4567 .A2 1584,6,"Pigna, Giovanni Battista"
-PQ4567 .A2 1584,7,"Rota, Giovanni"
-PQ4567 .A2 1584,8,"Camilli, Camillo"
-PQ4567 .A2 1584,9,"Ruscelli, Girolamo (Alessio Piemontese)"
-PQ4567 .A2 1584,10,Franceschi Francesco de'
-PQ4567 .A2 1584,11,"Porro, Girolamo"
+PQ4272.F5 A34 1697,1,George Gallet
+PQ4272.F5 A34 1697,2,Giovanni Boccaccio
+PQ4272.F5 A34 1697,3,Romeyn de Hooghe
+PQ4567 .A2 1584,0,Alberto Lavezzola
+PQ4567 .A2 1584,1,Girolamo Garofolo
+PQ4567 .A2 1584,2,Giuseppe Bononome
+PQ4567 .A2 1584,3,Luigi Groto
+PQ4567 .A2 1584,4,Niccolò Eugenico
+PQ4567 .A2 1584,5,Ludovico Ariosto
+PQ4567 .A2 1584,6,Giovanni Battista Pigna
+PQ4567 .A2 1584,7,Giovanni Rota
+PQ4567 .A2 1584,8,Camillo Camilli
+PQ4567 .A2 1584,9,Girolamo Ruscelli (Alessio Piemontese)
+PQ4567 .A2 1584,10,Francesco de' Franceschi
+PQ4567 .A2 1584,11,Girolamo Porro
 PS2267 .A1 1891,0,Houghton Mifflin Company
-PS2267 .A1 1891,1,"Remington, Frederic"
-PS2267 .A1 1891,2,"Longfellow, Henry Wadsworth"
-PS3519.O2625 G6 1927,0,"Douglas, Aaron"
-PS3519.O2625 G6 1927,1,"Johnson, James Weldon"
+PS2267 .A1 1891,1,Frederic Remington
+PS2267 .A1 1891,2,Henry Wadsworth Longfellow
+PS3519.O2625 G6 1927,0,Aaron Douglas
+PS3519.O2625 G6 1927,1,James Weldon Johnson
 PS3519.O2625 G6 1927,2,Viking Press
-PS3519.O2625 G6 1927,3,"Falls, Charles B."
+PS3519.O2625 G6 1927,3,Charles B. Falls
 QB7 .C15 1772,0,Pierre de Goesin
-SB472.32.E54 W48 1771,0,"Latapie, François de Paule"
-SB472.32.E54 W48 1771,1,"Whately, Thomas"
-SB472.32.E54 W48 1771,2,"Jombert, Charles Antoine"
+SB472.32.E54 W48 1771,0,François de Paule Latapie
+SB472.32.E54 W48 1771,1,Thomas Whately
+SB472.32.E54 W48 1771,2,Charles Antoine Jombert
 TA71 .F73 1829,0,Ministère de l'intérieur
 TA71 .F73 1829,1,L'Imprimerie Royale
 TL620.A1 A6 1784,0,Chez Jubert
 TL620.A1 A6 1784a,0,Chez Desnos
-TS1484 .B56 1777,0,"Bernieres, de"
+TS1484 .B56 1777,0,de Bernieres
 TS1484 .B56 1777,1,Clousier
-U101 .M7814 1760,0,"Montecuccoli, Raimondo, Prince"
-U565 .S68 1740,0,"Sparre, Baron de"
+U101 .M7814 1760,0,Prince Raimondo Montecuccoli
+U565 .S68 1740,0,Baron de Sparre
 U565 .S68 1740,1,Padeloup
-U820.A9 S34 1603 F,0,"Schrenck von Nozing, Jacob"
-U820.A9 S34 1603 F,1,"Noyse von Campenhouten, Johann Engelbert"
-U820.A9 S34 1603 F,2,"Baur, Daniel"
-U820.A9 S34 1603 F,3,"Custos, Dominicus"
-U820.A9 S34 1603 F,4,"Fontana, Giovanni Battista"
-UD S83 1842 v.1,0,Stephens John Lloyd
-UD S83 1843 v.2,0,Stephens John Lloyd
+U820.A9 S34 1603 F,0,Jacob Schrenck von Nozing
+U820.A9 S34 1603 F,1,Johann Engelbert Noyse von Campenhouten
+U820.A9 S34 1603 F,2,Daniel Baur
+U820.A9 S34 1603 F,3,Dominicus Custos
+U820.A9 S34 1603 F,4,Giovanni Battista Fontana
+UD S83 1842 v.1,0,John Lloyd Stephens
+UD S83 1843 v.2,0,John Lloyd Stephens

--- a/scripts/output/met_artwork/met_artwork-artwork_attribution-split.csv
+++ b/scripts/output/met_artwork/met_artwork-artwork_attribution-split.csv
@@ -1,0 +1,247 @@
+Object Number,variable,attribution
+04.3.36,0,Attributed to
+06.1335.1a–d,0,and
+06.1335.1a–d,1,Stuccowork probably by
+06.968.2,0,Decoration after designs by
+06.968.2,1,and
+06.968.2,2,Attributed to the pottery of
+06.968.2,3,Possibly assisted by
+"07.286.36a, b",0,Attributed to the
+07.286.84,0,Attributed to the
+10.125.685,0,Possibly
+10.125.83,0,Attributed to
+13.228.13.6,0,Painting by
+13.228.26,0,Painting attributed to
+13.228.28,0,Attributed to
+13.228.29,0,Painting by
+13.228.33,0,Painting by
+13.228.7.5,0,Painting by
+14.100.172,0,Helmet bowl signed
+14.100.172,1,"Breastplate inscribed inside,"
+14.130.12,0,Attributed to the
+14.130.14,0,Attributed to the
+14.74.17,0,Attributed to
+14.74.17,1,Attributed to
+15.113.1–.5; 29.158.885,0,Armor attributed to
+15.113.1–.5; 29.158.885,1,Helmet cheek pieces and metal plates on shoulder straps made by
+17.190.724,0,Attributed to
+17.190.823,0,Miniatures by
+"17.230.14a, b",0,Attributed to
+17.81.4,0,Painting attributed to
+19.115.2,0,Inscribed by
+"19.131.1a–r, t–w, .2a–c; 27.183.16",0,Made at the
+"19.131.1a–r, t–w, .2a–c; 27.183.16",1,Design of the decoration attributed to
+19.74.1,0,After
+1970.230.4,0,Attributed to
+1970.301.2,0,Painting attributed to
+1970.301.3,0,Painting attributed to
+1970.301.51,0,Painting attributed to
+1970.35.1,0,Attributed to
+1970.77,0,Hilt by
+1970.77,1,Blade by
+1973.120.1,0,Attributed to
+1974.356.120a,0,Attributed to
+1975.1.1103,0,workshop of
+1975.1.1194,0,Possibly
+1975.1.1638,0,possibly
+1975.1.1915,0,Designed by
+1975.1.1915,1,Probably woven by
+1975.1.2026,0,Attributed to
+1975.1.2026,1,various
+1975.1.335,0,Circle of
+1975.1.848,0,"Circle of Rogier van der Weyden, possibly"
+1975.1.95,0,Attributed to the
+1975.1.96,0,Attributed to the
+1976.155.110,0,Attributed to
+1976.155.110,1,Central plaque decorated by
+1976.92,0,and
+1977.1.11,0,Possibly by
+1982.213,0,Painting by
+1982.213,1,Painting by
+1982.324,0,labeled
+1982.60.129,0,Attributed to the
+1982.60.61,0,and
+1982.60.81,0,Designs for figural marquetry by
+1982.60.81,1,Stencil drawings and stamp-cutting of marquetry
+1982.60.81,2,Frieze mounts attributed to
+1983.356,0,Sculptor close to
+1984.225,0,Attributed to
+1985.116,0,Attributed to
+1986.237,0,Attributed to
+1986.239,0,Attributed to
+1986.353.2,0,Workshop of
+1986.365.3,0,Marquetry by
+1986.365.3,1,Designed and possibly engraved by
+1988.159,0,Attributed to
+1988.164,0,Design attributed to
+1988.65.1–.2,0,Helmet includes original paper label of
+1989.147,0,attributed to
+1989.197,0,Woodwork by
+1989.197,1,Mounts and large central plaque by
+1989.197,2,Designed by
+1989.281.72,0,Attributed to the
+1989.3,0,Signature probably refers to
+1990.103,0,Attributed to
+1990.223,0,Attributed to
+1990.247,0,Restored by
+"1991.373a, b",0,Blade inscribed by
+1992.279,0,Attributed to
+1992.43,0,Designed by
+1992.51,0,Painting by
+1993.14,0,Workshop of
+1993.415,0,Designed and steel chiseled by
+1993.415,1,Designed and steel chiseled by
+1993.75,0,Manufactured by
+1993.75,1,Designed by
+1994.141,0,Painting by
+1994.141,1,Commissioned by
+"1995.371a, b",0,Attributed to
+1996.14,0,Attributed to
+1997.36,0,Attributed to the
+1998.121,0,Possibly
+1998.21,0,commissioned by
+1998.479,0,Published by
+1998.479,1,Published by
+20.24.76,0,After
+2001.642,0,Helmet signed by
+2006.452a–c,0,Attributed to
+2007.194a–f,0,Workshop of
+2007.27,0,Possibly executed by
+2008.312,0,Painting attributed to
+2009.28,0,Partly based on a woodcut by
+2009.28,1,Woven by
+2010.466,0,Embroidered by
+216.7 T71,0,Introduction by:
+24.97.104,0,Attributed to the
+240.7 T344 F,0,Printer:
+240.7 T344 F,1,Engraver:
+25.115.15,0,Attributed to
+25.78.56,0,Copy of work attributed to
+"26.145.243a, b",0,Grip attributed to
+26.168.77,0,Silver mounts by
+26.168.77,1,Designed by
+26.168.77,2,Probably by
+26.168.77,3,Decoration after drawings by
+26.49,0,Signed by
+26.54,0,Painted by
+270.52 T49,0,Foreword by
+28.57.23,0,Attributed to the
+29.100.370,0,Cast by
+31.11.10,0,Attributed to the
+31.11.11,0,Attributed to
+31.11.13,0,Attributed to the
+31.11.5,0,Attributed to
+32.12,0,Plaster ceiling by
+32.12,1,Woodwork carved by
+32.12,2,Marble chimneypiece supplied by
+32.12,3,After a design by
+32.130.6a–y,0,Made under the direction of
+33.23,0,Attributed to
+"33.65.11, .226",0,Formerly attributed to
+34.100.124,0,Possibly
+"36.120.417a, b, .418a–c",0,Long sword (katana) blade inscribed by
+"36.120.417a, b, .418a–c",1,Short sword (wakizashi) blade attributed to
+"36.120.417a, b, .418a–c",2,Set of sword mountings by
+36.120.79,0,Inscribed by
+38.59,0,Probably
+39.121a–n,0,Part of the decoration design by
+39.121a–n,1,Part of the decoration design possibly by
+39.121a–n,2,Part of the decoration design possibly by
+39.153,0,Executed in the workshop of
+39.153,1,Designed by
+39.153,2,Executed under the supervision of
+39.153,3,and
+39.68.27,0,after
+41.82,0,Marquetry panel after a design by
+41.82,1,Case after a design by
+42.50.16,0,Attributed to
+42.50.2,0,"Stamped with the armorer's name,"
+"46.140.767a, b",0,Probably
+46.43.4,0,Attributed to
+46.43.4,1,Border probably designed by
+46.43.4,2,Probably made at the
+46.43.4,3,Commissioned for
+50.11.4,0,Attributed to the
+50.164,0,Painting by
+53.225.52,0,Follower of
+543.1N48 M97 Q,0,Introduction by
+55.121.10.22,0,Painting by
+55.121.10.24,0,Painting by
+56.11.1,0,Attributed to the
+56.171.38,0,Attributed to the
+56.171.64,0,Attributed to the
+56.70a–c,0,Workshop of
+57.130.7,0,Attributed to
+58.57a–d,0,Designed by
+58.57a–d,1,Marble piers carved by
+58.57a–d,2,Pietre Dure top attributed to
+58.75.1–.22,0,Plaster ceiling and cornice moldings by
+58.75.1–.22,1,Tapestry medallions after designs by
+58.75.1–.22,2,Tapestries and furniture covers manufactured by
+58.75.1–.22,3,Tapestry borders and seat covers designed by
+58.75.1–.22,4,and
+58.75.1–.22,5,and
+58.75.1–.22,6,Furniture and curtain cornices made by
+58.75.1–.22,7,Factory administrator:
+58.75.1–.22,8,Tapestry and seat furniture designs possibly by
+58.75.1–.22,9,with frieze carved by
+58.75.1–.22,10,Chimneypiece by
+58.75.1–.22,11,Grate basket and fender by
+58.75.1–.22,12,Chair rails and paneling carved by
+58.75.1–.22,13,Marquery commode made by
+58.75.1–.22,14,Doors by
+58.75.1–.22,15,for the firm
+58.75.1–.22,16,Room after a design by
+58.75.25,0,possibly embroidered by
+58.75.88a–c,0,Attributed to
+6.311,0,Roman copy of Greek original by
+"60.29.1a, b",0,Possibly by
+60.4.1,0,Attributed to
+62.16,0,Attributed to
+62.189,0,Workshop of
+62.96,0,Attributed to
+63.11.6,0,Signed by
+63.11.6,1,Attributed to the
+63.11.6,2,Attributed to the
+63.210.11,0,Painting by
+63.350.246.206.378,0,Issued by
+64.79,0,Attributed to
+64.79,1,Attributed to
+65.167.6,0,Attributed to
+65.167.6,1,Attributed to
+67.110.1,0,Commissioned by
+68.148,0,Attributed to the
+69.27,0,Written by
+69.27,1,Calligraphy and paintings by
+"77.9a, b",0,Designed by
+"77.9a, b",1,Manufactured by
+"77.9a, b",2,Chased by
+"77.9a, b",3,Medallions by
+89.4.1191,0,Organ mechanism made by
+89.4.1236,0,Attributed to
+89.4.2883,0,possibly
+903.6 R541 F,0,Lithographed by
+903.6 R541 F,1,Historical descriptions by
+96.17.10,0,Designed by
+99.2,0,Manufactured by
+99.2,1,Designed by
+AY831 .Z7 1784,0,Chez
+BV4823 .D48 1741,0,Engravings drawn by
+BX2010 .A2 1794,0,After
+BX2010 .A2 1794,1,After
+BX2010 .A2 1794,2,After
+BX2010 .A2 1794,3,Presso
+BX2016.A5 F7 1792,0,Chez
+BX9454 .S25 1688,0,Chez
+C.I.66.14.2,0,Textile by
+C.I.66.14.2,1,Textile by
+DC611.N846 A5 1788,0,Chez
+G150 .A45 1820,0,Chez
+PA4375.M8 D3 1772,0,De
+PQ1821 1773,0,De l'imprimerie de
+PQ1821 1773,1,Par
+PQ1954.A54 L4 1741,0,Chez
+PQ2067.T28 D4 1770,0,Erroneously attributed to
+PQ2067.T28 D4 1770,1,Aux depens de
+PQ4567 .A2 1584,0,Appresso
+SB472.32.E54 W48 1771,0,Chez

--- a/scripts/output/met_artwork/met_artwork-artwork_roles-split.csv
+++ b/scripts/output/met_artwork/met_artwork-artwork_roles-split.csv
@@ -1,0 +1,1458 @@
+Object Number,variable,role
+02.7.1,0,Artist
+04.29.2,0,Artist
+04.3.36,0,Maker
+06.1051.2,0,Artist
+06.1335.1a–d,0,Maker
+06.1335.1a–d,1,Artist
+06.968.2,0,Decorator
+06.968.2,1,Decorator
+06.968.2,2,Maker
+06.968.2,3,Maker
+08.162.1,0,Artist
+08.162.1,1,Artist
+08.183.1,0,Artist
+10.125.685,0,Maker
+10.125.685,1,Maker
+10.125.83,0,Maker
+10.189,0,Artist
+10.228.1,0,Artist
+10.64.5,0,Artist
+100.1 B59,0,Author
+100.1 B59,1,Illustrator
+100.1 B591,0,Illustrator
+100.1 B591,1,Author
+100.51 B61 no.2,0,Editor
+100.51 B61 no.2,1,Editor
+100.51 B61 no.2,2,Publisher
+106.1 V28 F,0,Publisher
+106.1 V28 F,1,Author
+107.1 K75 1920 no.8,0,Artist
+107.1 K75 1920 no.8,1,Publisher
+107.15 R474 no.7,0,Publisher
+109A L83,0,Author
+11.116.4,0,Artist
+11.118,0,Artist
+11.126.1,0,Artist
+11.156,0,Artist
+11.173.1,0,Artist
+110.5B75 C44,0,Author
+12.11.1,0,Artist
+12.3.1,0,Artist
+120 Se6,0,Author
+120.32P17 P17,0,Author
+123.1 F412,0,Publisher
+123.1 F412,1,Author
+125.97 D932,0,Author
+126.5V55 B292 Q v.3,0,Editor
+126.5V55 B292 Q v.3,1,Publisher
+126.6 R61,0,Publisher
+126.6 R61,1,Author
+126.6 R61,2,Author
+13.160.10,0,Author
+13.2,0,Artist
+13.228.13.6,0,Calligrapher
+13.228.13.6,1,Poet
+13.228.13.6,2,Artist
+13.228.26,0,Artist
+13.228.26,1,Poet
+13.228.28,0,Artist
+13.228.28,1,Poet
+13.228.29,0,Artist
+13.228.29,1,Calligrapher
+13.228.29,2,Poet
+13.228.33,0,Artist
+13.228.33,1,Calligrapher
+13.228.33,2,Poet
+13.228.7.5,0,Calligrapher
+13.228.7.5,1,Calligrapher
+13.228.7.5,2,Artist
+13.228.7.5,3,Author
+130.8 C23,0,Author
+131.1M58 C75,0,Author
+139.3 N48 F,0,Author
+139.3 N48 F,1,Publisher
+139.3 N48 F,2,Author
+139.3 N48 F,3,Author
+139.3 N48 F,4,Author
+139.3 N48 F,5,Author
+14.100.172,0,Armorer
+14.100.172,1,Armorer
+14.126.1,0,Artist
+14.25.1425,0,Etcher
+14.25.1425,1,Gunsmith
+14.25.1623,0,Maker
+14.26,0,Maker
+14.40.602,0,Artist
+14.40.605,0,Artist
+14.40.618,0,Artist
+14.40.619,0,Artist
+14.40.623,0,Artist
+14.40.626–27,0,Artist
+14.40.633,0,Artist
+14.40.642,0,Artist
+14.40.675,0,Artist
+14.40.687,0,Artist
+14.40.689,0,Artist
+14.74.17,0,Maker
+14.74.17,1,Maker
+14.76.6,0,Artist
+143.6 S92,0,Author
+143.7W41 W413,0,Artist
+146.8  M821 Q,0,Author
+146.8  M821 Q,1,Author
+146.9 T34,0,Author
+15.113.1–.5; 29.158.885,0,Armorer
+15.113.1–.5; 29.158.885,1,Armorer
+15.142.2,0,Artist
+15.30.59,0,Artist
+15.30.61,0,Artist
+15.30.62,0,Artist
+15.30.67,0,Artist
+15.75,0,Artist
+152.7 T36 Q,0,Author
+153 Ar7 F,0,Publisher
+159.4 N486,0,Printer
+159.4 N486,1,Designer
+159.4 N486,2,Subject of book
+159.4 N486,3,Publisher
+16.2.2,0,Artist
+16.30ab,0,Artist
+16.53,0,Artist
+16.68.2,0,Artist
+161 H41,0,Publisher
+161 H41,1,Author
+161 L841,0,Printer
+161 L841,1,Publisher
+161 L841,2,Author
+161.1 C44 Q,0,Author
+17.104,0,Artist
+17.142.1,0,Artist
+17.172,0,Artist
+17.190.1720,0,Armorer
+17.190.2045,0,Factory
+17.190.636,0,Maker
+17.190.724,0,Artist
+17.190.823,0,Maker
+17.190.823,1,Artist
+17.3.159,0,Artist
+17.3.90,0,Artist
+17.40.2a–r,0,Artist
+17.50.17-36,0,Artist
+17.50.17-36,1,Dedicatee
+17.50.17-36,2,Publisher
+17.81.4,0,Artist
+17.81.4,1,Poet
+"17.87.3a, b",0,Sword maker
+17.90.1,0,Artist
+17.97.5,0,Artist
+170.1 AL1 Quarto,0,Author
+170.1 AL1 Quarto,1,Publisher
+170.1 C424,0,Author
+170.1 C424,1,Translator
+170.1 R674,0,Author
+170.9 F46,0,Author
+171.1 C17,0,Author
+171.1 C17,1,Publisher
+171.1 C17,2,Engraver
+171.1 C17,3,Engraver
+175T49 R43,0,Author
+18.70.28,0,Artist
+19.115.2,0,Maker
+19.126,0,Artist
+"19.131.1a–r, t–w, .2a–c; 27.183.16",0,Armorer
+"19.131.1a–r, t–w, .2a–c; 27.183.16",1,Designer
+19.164,0,Artist
+19.51.7,0,Artist
+19.51.7,1,Sitter
+19.68.1,0,Author
+19.73.1,0,Artist
+19.74.1,0,Artist
+19.74.1,1,Artist
+19.77.2,0,Artist
+192H221  B61,0,Author
+1950-04-01 00:00:00,0,Photographer
+1970.137.1,0,Artist
+1970.179.1a–q,0,Gunsmith
+1970.230.4,0,Manufactory
+1970.230.4,1,Modeler
+1970.301.2,0,Artist
+1970.301.2,1,Author
+1970.301.3,0,Artist
+1970.301.3,1,Author
+1970.301.51,0,Artist
+1970.301.51,1,Author
+1970.35.1,0,Maker
+1970.727.1,0,Artist
+1970.77,0,Sword cutler
+1970.77,1,Bladesmith
+1970.89.1a–c,0,Designer
+1971.155,0,Artist
+1971.158.1,0,Artist
+1971.219,0,Maker
+1971.63.1,0,Artist
+1971.79.4,0,Designer
+1971.79.4,1,Design House
+1971.86,0,Artist
+1972.111.1a-c,0,Maker
+1972.118.210,0,Artist
+1972.127,0,Artist
+1972.223,0,Gunsmith
+1972.223,1,Gunsmith
+1972.263.6,0,Artist
+1972.47,0,Maker
+1972.60.1,0,Maker
+"1973.104.2a, b",0,Designer
+1973.120.1,0,Artist
+1973.120.6,0,Artist
+1973.257,0,Artist
+1973.282.2,0,Design House
+1973.282.2,1,Designer
+1973.315.1,0,Maker
+1973.634,0,Artist
+"1973.6a, b",0,Designer
+1974.136.3,0,Designer
+1974.185.3a–c,0,Designer
+1974.185.3a–c,1,Designer
+"1974.214.26a, b",0,Maker
+"1974.214.26a, b",1,Retailer
+1974.356.120a,0,Maker
+1974.356.524,0,Modeler
+1974.356.524,1,Manufactory
+1975.1.1015,0,Artist
+1975.1.1019,0,Artist
+1975.1.103,0,Artist
+1975.1.104,0,Artist
+1975.1.110,0,Artist
+1975.1.1103,0,Artist
+1975.1.113,0,Artist
+1975.1.119,0,Artist
+1975.1.1194,0,Artist
+1975.1.1194,1,Artist
+1975.1.12,0,Artist
+1975.1.120,0,Artist
+1975.1.1232,0,Artist
+1975.1.1232,1,Artist
+1975.1.1244,0,Artist
+1975.1.130,0,Artist
+1975.1.138,0,Artist
+1975.1.140,0,Artist
+1975.1.141,0,Artist
+1975.1.142,0,Artist
+1975.1.144,0,Artist
+1975.1.145,0,Artist
+1975.1.146,0,Artist
+1975.1.148,0,Artist
+1975.1.155,0,Artist
+1975.1.1558,0,Artist
+1975.1.1558,1,Artist
+1975.1.156,0,Artist
+1975.1.159,0,Artist
+1975.1.16,0,Artist
+1975.1.160,0,Artist
+1975.1.162,0,Artist
+1975.1.1638,0,Artist
+1975.1.168,0,Artist
+1975.1.186,0,Artist
+1975.1.1915,0,Artist
+1975.1.1915,1,Artist
+1975.1.192,0,Artist
+1975.1.194,0,Artist
+1975.1.196,0,Artist
+1975.1.199,0,Artist
+1975.1.201,0,Artist
+1975.1.2026,0,Artist
+1975.1.2026,1,Artist
+1975.1.2026,2,Artist
+1975.1.209,0,Artist
+1975.1.21,0,Artist
+1975.1.2101,0,Artist
+1975.1.225,0,Artist
+1975.1.231,0,Artist
+1975.1.2486,0,Artist
+1975.1.2487,0,Artist
+1975.1.2490,0,Artist
+1975.1.2491,0,Artist
+1975.1.27,0,Artist
+1975.1.270,0,Artist
+1975.1.297,0,Artist
+1975.1.31,0,Artist
+1975.1.335,0,Artist
+1975.1.342,0,Artist
+1975.1.369,0,Artist
+1975.1.37,0,Artist
+1975.1.376,0,Artist
+1975.1.38,0,Artist
+1975.1.410,0,Artist
+1975.1.443,0,Artist
+1975.1.473,0,Artist
+1975.1.514,0,Artist
+1975.1.54,0,Artist
+1975.1.553,0,Artist
+1975.1.58,0,Artist
+1975.1.592,0,Artist
+1975.1.647,0,Artist
+1975.1.66,0,Artist
+1975.1.661,0,Artist
+1975.1.669,0,Artist
+1975.1.7,0,Artist
+1975.1.704,0,Artist
+1975.1.710,0,Artist
+1975.1.731,0,Artist
+1975.1.736,0,Artist
+1975.1.74,0,Artist
+1975.1.753,0,Artist
+1975.1.763,0,Artist
+1975.1.774,0,Artist
+1975.1.792,0,Artist
+1975.1.794,0,Artist
+1975.1.799,0,Artist
+1975.1.843,0,Artist
+1975.1.848,0,Artist
+1975.1.85,0,Artist
+1975.1.855,0,Artist
+1975.1.859,0,Artist
+1975.1.86,0,Artist
+1975.1.872,0,Artist
+1975.1.940,0,Artist
+1975.1.95,0,Artist
+1975.1.96,0,Artist
+1975.15a–c,0,Designer
+1975.16,0,Artist
+1975.246.5a–c,0,Designer
+1975.268.48a–d,0,Artist
+1975.27.1,0,Artist
+1975.319.1,0,Artist
+1975.321,0,Artist
+1975.59,0,Maker
+1976.124.7a–c,0,Designer
+1976.124.7a–c,1,Design House
+1976.155.110,0,Maker
+1976.155.110,1,Decorator
+1976.155.110,2,Factory
+1976.324,0,Maker
+1976.332,0,Artist
+"1976.368.5a, b",0,Designer
+"1976.368.5a, b",1,Manufacturer
+"1976.368.5a, b",2,Department Store
+1976.414.3a-ggg,0,Designer
+1976.414.3a-ggg,1,Manufacturer
+1976.646,0,Artist
+1976.652.3-4,0,Artist
+1976.92,0,Artist
+1976.92,1,Artist
+1977.1,0,Artist
+1977.1.11,0,Maker
+1977.1.3,0,Artist
+1977.243,0,Artist
+"1977.329.5a, b",0,Manufacturer
+"1977.329.5a, b",1,Designer
+"1977.329.5a, b",2,Design House
+1977.78,0,Artist
+1978.163.2a–c,0,Designer
+1978.203,0,Artist
+1978.288.23a–f,0,Designer
+1978.288.23a–f,1,Department Store
+"1978.288.7a, b",0,Design House
+1978.412.499,0,Artist
+1978.61.1-.6,0,Artist
+1979.206.1047,0,Artist
+1979.29,0,Artist
+1979.32,0,Designer
+"1979.380a, b",0,Maker
+1979.394,0,Artist
+1979.395,0,Artist
+1979.396.1,0,Artist
+"1979.435.10a, b",0,Designer
+"1979.435.10a, b",1,Design House
+1979.5a–d,0,Artist
+1979.622,0,Artist
+1980.1023.5,0,Artist
+"1980.111a,b",0,Maker
+1980.351,0,Designer
+1980.42,0,Artist
+1980.92.1a–c,0,Design House
+1981.238,0,Artist
+1981.276,0,Artist
+1981.278,0,Artist
+1981.35,0,Artist
+1981.380.2,0,Design House
+1981.4.1a–o,0,Artist
+"1981.57.2a, b",0,Artist
+1982.147.25,0,Artist
+1982.16.3,0,Artist
+1982.171.1,0,Maker
+1982.179.29,0,Artist
+1982.213,0,Artist
+1982.213,1,Artist
+1982.30ab,0,Designer
+1982.324,0,Maker
+1982.443.2,0,Artist
+1982.45,0,Artist
+"1982.4a, b",0,Maker
+"1982.4a, b",1,Maker
+1982.53,0,Artist
+1982.55.1,0,Artist
+1982.59.1–.105,0,Maker
+1982.60.129,0,Artist
+1982.60.61,0,Maker
+1982.60.61,1,Maker
+1982.60.81,0,Maker
+1982.60.81,1,Designer
+1982.60.81,2,Decorator
+1982.60.81,3,Maker
+1982.60.82,0,Maker
+1982.90.1a-c,0,Artist
+1983.1009(8),0,Artist
+1983.251,0,Artist
+1983.356,0,Artist
+1983.451,0,Artist
+1983.457,0,Artist
+1983.606.14–.22,0,Artist
+"1983.619.1a, b",0,Designer
+"1983.619.1a, b",1,Design House
+"1983.8a, b",0,Designer
+1984.114.1,0,Maker
+"1984.163.4a, b",0,Design House
+"1984.163.4a, b",1,Designer
+1984.194,0,Artist
+1984.225,0,Maker
+1984.256,0,Maker
+1984.3,0,Designer
+1984.3,1,Design House
+1984.315.42,0,Artist
+1984.328a-d,0,Artist
+1984.331.13,0,Maker
+1984.34,0,Maker
+1984.425,0,Maker
+1984.433.16,0,Artist
+1984.433.294,0,Artist
+1984.433.298ab,0,Artist
+1984.433.34,0,Artist
+1984.459.1,0,Artist
+1984.459.2,0,Artist
+1984.527,0,Artist
+1984.613.2,0,Artist
+1985.114,0,Artist
+1985.116,0,Maker
+1985.124,0,Maker
+1985.353,0,Artist
+1985.63.5,0,Artist
+1986.1053.1,0,Artist
+1986.1054.19,0,Artist
+1986.1159,0,Artist
+1986.1225.2,0,Artist
+1986.138,0,Artist
+1986.237,0,Maker
+1986.239,0,Maker
+"1986.265.1, .2",0,Gunsmith
+1986.266.4,0,Artist
+1986.353.1,0,Maker
+1986.353.2,0,Maker
+1986.365.3,0,Maker
+1986.365.3,1,Designer
+1986.397,0,Artist
+1986.441.3,0,Artist
+1987.1100.1,0,Artist
+1987.1100.10,0,Artist
+1987.1100.13,0,Artist
+1987.1100.384,0,Artist
+1987.1100.40,0,Artist
+1987.1100.47,0,Artist
+1987.1100.476,0,Artist
+1987.1100.48,0,Artist
+1987.1100.482,0,Artist
+1987.1100.49,0,Artist
+1987.1100.87,0,Artist
+1987.1161,0,Artist
+1987.12,0,Maker
+1987.282,0,Artist
+1987.455.2,0,Artist
+1987.47.1,0,Artist
+1987.88,0,Artist
+1988.103,0,Artist
+1988.1031,0,Artist
+1988.159,0,Artist
+1988.162,0,Artist
+1988.164,0,Manufactory
+1988.164,1,Designer
+1988.294.1,0,Factory
+1988.294.1,1,Modeler
+1988.65.1–.2,0,Maker
+1988.74.2a–e,0,Designer
+1988.87,0,Maker
+1989.1038.2,0,Artist
+1989.1063,0,Artist
+1989.1083,0,Artist
+1989.1135,0,Artist
+1989.147,0,Maker
+1989.183,0,Artist
+1989.197,0,Maker
+1989.197,1,Artist
+1989.197,2,Designer
+1989.3,0,Armorer
+1989.363.4,0,Artist
+1990.1005,0,Artist
+1990.103,0,Maker
+1990.1083,0,Artist
+1990.113,0,Artist
+1990.223,0,Maker
+1990.226a–d,0,Maker
+1990.237a-c,0,Artist
+1990.38.1,0,Artist
+1990.38.3,0,Artist
+1991.1044,0,Artist
+1991.1056,0,Artist
+1991.1127,0,Artist
+1991.1198,0,Artist
+1991.1232,0,Artist
+1991.1233,0,Artist
+1991.145,0,Maker
+1991.311.1,0,Maker
+"1991.373a, b",0,Swordsmith
+1991.77,0,Artist
+1992.128,0,Artist
+1992.146,0,Artist
+1992.23,0,Manufacturer
+1992.24.1,0,Artist
+1992.24.3,0,Artist
+1992.24.8,0,Artist
+1992.269,0,Maker
+1992.279,0,Maker
+1992.333,0,Maker
+1992.391,0,Artist
+1992.43,0,Designer
+1992.5,0,Artist
+1992.5067,0,Artist
+1992.51,0,Artist
+1992.5107,0,Artist
+1992.5147,0,Artist
+1992.5149,0,Artist
+1992.5152,0,Artist
+1992.5154,0,Artist
+1992.5158,0,Artist
+1992.8,0,Maker
+"1992.8.1, .2",0,Artist
+1993.1097,0,Artist
+1993.132,0,Artist
+1993.14,0,Sword maker
+1993.195a–s,0,Artist
+1993.303a-f,0,Designer
+1993.303a-f,1,Manufacturer
+1993.324,0,Artist
+1993.332.2,0,Artist
+1993.393.1,0,Designer
+1993.393.1,1,Design House
+1993.400.6,0,Artist
+1993.415,0,Barrelsmith
+1993.415,1,Gunsmith
+1993.415,2,Engraver
+1993.415,3,Goldsmith
+1993.415,4,Goldsmith
+1993.52.3,0,Designer
+1993.52.3,1,Design House
+1993.52.4,0,Designer
+1993.52.4,1,Design House
+1993.55,0,Designer
+1993.55,1,Design House
+1993.69.3,0,Artist
+1993.7,0,Artist
+1993.71,0,Artist
+1993.75,0,Manufacturer
+1993.75,1,Designer
+1993.96,0,Designer
+1994.12,0,Designer
+1994.141,0,Artist
+1994.141,1,Patron
+1994.141,2,Author
+1994.144.8,0,Artist
+1994.182,0,Artist
+1994.245.135,0,Artist
+1994.269,0,Artist
+1994.271,0,Artist
+1994.278,0,Designer
+1994.278,1,Design House
+1994.417,0,Artist
+1994.417,1,Artist
+1994.45,0,Artist
+1994.486,0,Artist
+1994.567,0,Artist
+"1994.578.3a, b",0,Designer
+1994.76,0,Artist
+1994.83,0,Artist
+1995.101,0,Artist
+1995.12,0,Artist
+1995.13,0,Maker
+1995.14.5,0,Artist
+1995.142,0,Artist
+1995.15,0,Artist
+1995.191,0,Artist
+1995.196,0,Artist
+1995.213a–h,0,Designer
+1995.234,0,Artist
+1995.245.1,0,Designer
+1995.251,0,Artist
+1995.336,0,Manufacturer
+"1995.371a, b",0,Maker
+1995.377.1,0,Maker
+1995.378,0,Artist
+1995.440a-c,0,Designer
+1995.440a-c,1,Manufacturer
+1995.474,0,Artist
+1995.595,0,Artist
+1995.72.7,0,Designer
+1995.96.10,0,Artist
+1996.102,0,Artist
+1996.13.1,0,Maker
+1996.14,0,Artist
+1996.279,0,Artist
+1996.291a–c,0,Artist
+1996.297,0,Artist
+1996.299,0,Artist
+1996.322,0,Artist
+1996.363.2,0,Artist
+"1996.364a, b",0,Artist
+1996.382,0,Artist
+1996.403.1,0,Artist
+1996.403.10,0,Artist
+1996.403.7ab,0,Artist
+1996.403.8,0,Artist
+1996.418,0,Artist
+1996.480.3,0,Designer
+1996.558,0,Artist
+1996.561,0,Artist
+1996.563,0,Artist
+1996.99.2,0,Artist
+1997.108,0,Artist
+1997.117.10,0,Artist
+1997.149.12,0,Artist
+1997.149.9,0,Artist
+1997.153,0,Artist
+1997.156,0,Artist
+1997.167,0,Artist
+1997.195,0,Artist
+1997.207,0,Artist
+1997.228,0,Designer
+1997.25,0,Artist
+1997.250.6,0,Designer
+1997.382.1,0,Artist
+1997.382.19,0,Artist
+1997.382.19,1,Artist
+1997.382.19,2,Photography Studio
+1997.382.34,0,Artist
+1997.382.35,0,Artist
+1997.382.38,0,Artist
+1997.382.41,0,Artist
+1997.382.46,0,Artist
+1997.460.1a–d,0,Manufacturer
+1997.460.1a–d,1,Designer
+1997.4ab,0,Artist
+1997.61.19,0,Artist
+1997.61.25,0,Artist
+1997.93,0,Artist
+1998.121,0,Maker
+1998.132,0,Artist
+1998.21,0,Artist
+1998.21,1,Patron
+1998.225,0,Artist
+1998.311.1,0,Artist
+1998.329,0,Artist
+1998.338,0,Artist
+1998.365,0,Artist
+1998.431.1a–e,0,Designer
+1998.431.1a–e,1,Manufacturer
+1998.479,0,Publisher
+1998.479,1,Artist
+1998.479,2,Publisher
+"1998.493.189a, b",0,Designer
+1998.57,0,Artist
+1998.57,1,Artist
+1998.57,2,Person in Photograph
+1998.7,0,Maker
+1999.103,0,Artist
+1999.176,0,Artist
+1999.18,0,Artist
+1999.19,0,Artist
+1999.2,0,Artist
+1999.21,0,Artist
+1999.222,0,Artist
+1999.237.4,0,Artist
+1999.24,0,Artist
+1999.26,0,Maker
+1999.27.1a-c-5,0,Designer
+1999.27.1a-c-5,1,Manufacturer
+"1999.307 a,b",0,Maker
+1999.363.15,0,Artist
+1999.363.16,0,Artist
+1999.363.20,0,Artist
+1999.363.22,0,Artist
+1999.363.41,0,Artist
+1999.363.50,0,Artist
+1999.363.53,0,Artist
+1999.38,0,Artist
+1999.396,0,Maker
+1999.399,0,Maker
+1999.494a–h,0,Designer
+1999.494a–h,1,Design House
+1999.58a–d,0,Designer
+1999.58a–d,1,Design House
+1999.93,0,Maker
+20.155.1,0,Artist
+20.155.11,0,Maker
+20.155.3,0,Artist
+20.155.8,0,Artist
+20.155.9,0,Artist
+20.24.76,0,Artist
+20.24.76,1,Artist
+2000.127,0,Artist
+2000.13,0,Artist
+2000.151,0,Artist
+2000.272,0,Artist
+2000.278.1-.9,0,Designer
+2000.278.1-.9,1,Manufacturer
+2000.51,0,Artist
+2000.512,0,Artist
+2000.600.15,0,Designer
+2000.600.15,1,Manufacturer
+2000.63a-c,0,Designer
+2001.153,0,Artist
+2001.293,0,Artist
+2001.402a,0,Artist
+2001.474,0,Artist
+2001.608.1,0,Artist
+2001.641,0,Artist
+2001.642,0,Armorer
+2001.723,0,Designer
+"2001.742a, b",0,Design House
+"2001.742a, b",1,Designer
+2002.1,0,Artist
+2002.115,0,Manufacturer
+2002.190a–n,0,Maker
+2002.21.1,0,Artist
+2002.259,0,Artist
+2002.26,0,Artist
+2002.323 a-f,0,Maker
+2002.323 a-f,1,Maker
+2002.365,0,Designer
+2002.365,1,Designer
+2002.436,0,Artist
+2002.456.1,0,Artist
+2002.456.111,0,Artist
+2002.468,0,Artist
+"2003.12a, b",0,Designer
+"2003.12a, b",1,Manufacturer
+2003.150a–g,0,Maker
+2003.241,0,Calligrapher
+2003.269,0,Artist
+2003.27,0,Artist
+2003.323,0,Artist
+2003.442,0,Design House
+2003.442,1,Designer
+2003.462,0,Design House
+2003.462,1,Designer
+2003.63a–d,0,Maker
+"2003.68a, b",0,Designer
+2004.442,0,Artist
+2005.100.1,0,Artist
+2005.100.109,0,Artist
+2005.100.116,0,Artist
+2005.100.140,0,Artist
+2005.100.27,0,Artist
+2005.364.1a–d–.48,0,Artist
+2005.365,0,Manufacturer
+2005.390a-c,0,Artist
+2005.44.2,0,Designer
+2006.277a-fff,0,Artist
+2006.32.15,0,Artist
+2006.32.49,0,Artist
+2006.32.5,0,Artist
+"2006.420.51a, b",0,Designer
+"2006.420.51a, b",1,Design House
+2006.452a–c,0,Maker
+"2006.519a, b",0,Designer
+"2006.519a, b",1,Manufactory
+2006.86a–c,0,Maker
+2006.91,0,Artist
+2007.194a–f,0,Maker
+2007.194a–f,1,Maker
+2007.27,0,Designer
+2007.27,1,Maker
+2007.329,0,Artist
+2007.442,0,Artist
+2007.95,0,Artist
+2007.96,0,Artist
+2008.1,0,Maker
+2008.121,0,Artist
+2008.253,0,Artist
+2008.278,0,Artist
+2008.29,0,Artist
+2008.312,0,Artist
+2008.459,0,Artist
+2008.547.1,0,Artist
+2009.28,0,Designer
+2009.28,1,Artist
+2009.28,2,Maker
+2009.300.816,0,Designer
+2009.58,0,Maker
+2009.8a–c,0,Sword cutler
+201.9 Av3,0,Author
+201.9Av3 Av32,0,Author
+201.9F88 B73,0,Author
+2010.121,0,Artist
+2010.138.1-.4,0,Maker
+2010.23,0,Artist
+2010.24,0,Maker
+2010.466,0,Maker
+2011.36,0,Artist
+2012.99,0,Artist
+2014.173,0,Artist
+2014.269,0,Artist
+21.115.4,0,Artist
+21.164,0,Artist
+216.7 T71,0,Author
+216.7 T71,1,Author
+217.08  W881,0,Author
+22.16.17,0,Artist
+"22.19a, b",0,Silversmith
+22.207,0,Artist
+22.61,0,Artist
+22.75,0,Artist
+221.1 K63,0,Author
+226 B641,0,Author
+23.101,0,Artist
+23.102,0,Artist
+23.163.4a,0,Designer
+23.163.4a,1,Manufacturer
+23.163.4a,2,Printer
+23.31.1,0,Artist
+23.31.1,1,Printer
+23.31.1,2,Publisher
+230.51 N55,0,Publisher
+230.51 N55,1,Author
+239 B63 Q,0,Author
+239 B63 Q,1,Engraver
+"24.179; 26.188.1, .2; 29.158.363a, b",0,Armorer
+24.197.2,0,Artist
+24.241.2,0,Maker
+24.45.1,0,Artist
+240.7 T344 F,0,Publisher
+240.7 T344 F,1,Artist
+240.7 T344 F,2,Author
+25.115.15,0,Maker
+25.120.288,0,Artist
+25.17,0,Artist
+25.17,1,Author
+25.17,2,Printer
+25.231.1,0,Designer
+250 T34,0,Author
+254 B63,0,Author
+26.117,0,Artist
+26.12,0,Artist
+"26.145.243a, b",0,Sword maker
+"26.145.315a, b",0,Goldsmith
+26.168.77,0,Maker
+26.168.77,1,Designer
+26.168.77,2,Maker
+26.168.77,3,Decorator
+26.54,0,Designer
+26.54,1,Artist
+26.54,2,Manufacturer
+26.72.68,0,Artist
+26.9,0,Artist
+26.97,0,Artist
+27.137,0,Artist
+270.52 T49,0,Author
+270.52 T49,1,Author
+272.4 Au8,0,Author
+273.4 G76,0,Author
+273.4 G76,1,Illustrator
+273.4D26 AL2,0,Subject of book
+273.4D26 AL2,1,Author
+28.221,0,Artist
+"28.52a, b",0,Maker
+"28.52a, b",1,Maker
+29.100.115,0,Artist
+29.100.129,0,Artist
+29.100.16,0,Artist
+29.100.200,0,Artist
+29.100.23,0,Artist
+29.100.370,0,Artist
+29.100.370,1,Founder
+29.100.5,0,Artist
+29.100.53,0,Artist
+29.100.565,0,Artist
+29.100.57,0,Artist
+29.100.6,0,Artist
+29.100.66,0,Artist
+29.100.939,0,Artist
+29.107.28,0,Artist
+3.3,0,Artist
+30.5,0,Maker
+31.109,0,Artist
+31.45,0,Artist
+31.62,0,Artist
+32.100.43,0,Artist
+32.12,0,Maker
+32.12,1,Maker
+32.12,2,Maker
+32.12,3,Designer
+32.130.2,0,Artist
+32.130.6a–y,0,Armorer
+33.120.221,0,Maker
+33.164a–x,0,Armorer
+33.165.1,0,Maker
+33.23,0,Artist
+33.43.132,0,Artist
+33.43.303,0,Artist
+33.43.334,0,Artist
+33.43.343,0,Artist
+33.43.36,0,Artist
+33.43.39,0,Artist
+33.43.43,0,Artist
+33.43.44,0,Artist
+33.43.47,0,Artist
+33.61,0,Artist
+"33.65.11, .226",0,Artist
+"33.65.11, .226",1,Former Attribution
+33.7,0,Author
+33.92ab,0,Artist
+34.100.124,0,Maker
+34.134,0,Artist
+34.138,0,Artist
+34.73,0,Artist
+34.86.1 a,0,Maker
+34.86.2 a,0,Maker
+34.92,0,Artist
+35.27,0,Artist
+35.42,0,Artist
+"36.120.417a, b, .418a–c",0,Swordsmith
+"36.120.417a, b, .418a–c",1,Swordsmith
+"36.120.417a, b, .418a–c",2,Fittings maker
+36.120.79,0,Fittings maker
+36.14a–c,0,Artist
+36.37 (25),0,Artist
+37.165.107,0,Artist
+37.45.3(27),0,Artist
+37.45.3(27),1,Publisher
+38.34,0,Artist
+38.34,1,Artist
+38.34,2,Photography Studio
+38.59,0,Maker
+38.63,0,Maker
+39.121a–n,0,Designer
+39.121a–n,1,Designer
+39.121a–n,2,Designer
+39.153,0,Maker
+39.153,1,Designer
+39.153,2,Maker
+39.153,3,Maker
+39.52,0,Artist
+39.65.53,0,Artist
+39.68.27,0,Artist
+39.68.27,1,Artist
+41.1.31,0,Artist
+41.100.132,0,Artist
+41.100.23,0,Artist
+41.138,0,Artist
+41.82,0,Maker
+41.82,1,Designer
+41.82,2,Designer
+42.154,0,Artist
+42.155,0,Artist
+42.167,0,Artist
+42.22,0,Gunsmith
+42.50.16,0,Maker
+42.50.2,0,Armorer
+43.106.1,0,Artist
+43.13,0,Artist
+43.159.1,0,Artist
+43.86.4,0,Artist
+43.87.17,0,Artist
+43.87.23,0,Artist
+"44.21a, b",0,Artist
+45.128.5,0,Artist
+45.62.1,0,Artist
+"46.140.767a, b",0,Maker
+46.16,0,Artist
+46.192.4,0,Artist
+46.25.1a–d,0,Designer
+46.25.1a–d,1,Design House
+46.43.4,0,Designer
+46.43.4,1,Designer
+46.43.4,2,Manufactory
+46.43.4,3,Patron
+47.106,0,Artist
+47.26,0,Artist
+48.190.2,0,Artist
+48.81,0,Maker
+49.12,0,Artist
+49.24,0,Artist
+49.3,0,Artist
+49.38,0,Artist
+49.55.327,0,Artist
+49.55.35,0,Artist
+49.59.1,0,Artist
+49.7.10,0,Artist
+49.7.108,0,Artist
+49.7.16,0,Artist
+49.7.19,0,Artist
+49.7.21,0,Artist
+49.7.41,0,Artist
+49.7.49,0,Artist
+49.70.1,0,Artist
+49.70.105,0,Artist
+49.70.42,0,Artist
+50.102.4,0,Designer
+50.102.4,1,Designer
+50.117,0,Artist
+50.135.4,0,Artist
+50.135.5,0,Artist
+50.145.66,0,Artist
+50.145.8,0,Artist
+50.164,0,Artist
+50.228.3,0,Maker
+50.583.4,0,Artist
+51.112.1,0,Artist
+51.112.2,0,Artist
+51.112.5,0,Artist
+51.33.2,0,Artist
+51.56,0,Maker
+51.9,0,Artist
+52.184,0,Artist
+52.203,0,Artist
+52.81,0,Artist
+526 R82,0,Author
+526 R82,1,Publisher
+53.223,0,Maker
+53.225.52,0,Maker
+53.56.11,0,Maker
+53.87a-i,0,Artist
+53.9,0,Artist
+532 Eg961,0,Author
+532 L551,0,Author
+532 L551,1,Author
+532 L551,2,Author
+"54.1.1a, b",0,Artist
+54.1.2,0,Artist
+54.167,0,Maker
+543.1N48 M97 Q,0,Author
+543.1N48 M97 Q,1,Author
+55.119,0,Artist
+55.121.10.22,0,Artist
+55.121.10.22,1,Calligrapher
+55.121.10.24,0,Artist
+55.44,0,Calligrapher
+55.44,1,Illuminator
+55.86 a-c,0,Maker
+55.93,0,Artist
+551 G41,0,Publisher
+551 G41,1,Author
+56.105,0,Artist
+56.205.1,0,Artist
+56.228,0,Artist
+56.70a–c,0,Artist
+57.130.7,0,Maker
+57.51.21,0,Calligrapher
+57.51.23,0,Author
+57.51.23,1,Calligrapher
+57.51.26,0,Artist
+57.92,0,Artist
+58.57a–d,0,Designer
+58.57a–d,1,Maker
+58.57a–d,2,Maker
+58.75.1–.22,0,Maker
+58.75.1–.22,1,Designer
+58.75.1–.22,2,Manufacturer
+58.75.1–.22,3,Designer
+58.75.1–.22,4,Designer
+58.75.1–.22,5,Maker
+58.75.1–.22,6,Maker
+58.75.1–.22,7,Factory director
+58.75.1–.22,8,Designer
+58.75.1–.22,9,Maker
+58.75.1–.22,10,Maker
+58.75.1–.22,11,Maker
+58.75.1–.22,12,Maker
+58.75.1–.22,13,Maker
+58.75.1–.22,14,Maker
+58.75.1–.22,15,Maker
+58.75.1–.22,16,Designer
+58.75.25,0,Maker
+58.75.25,1,Artist
+58.75.88a–c,0,Decorator
+58.75.88a–c,1,Modeler
+58.75.88a–c,2,Factory
+58.89,0,Artist
+59.12,0,Artist
+59.166,0,Artist
+59.76,0,Designer
+59.76,1,Manufacturer
+6.1234,0,Artist
+6.1312,0,Maker
+6.1312,1,Maker
+6.306,0,Artist
+"60.29.1a, b",0,Maker
+60.3,0,Artist
+60.4.1,0,Maker
+60.87,0,Artist
+61.101.1,0,Artist
+61.101.16,0,Artist
+61.101.17,0,Artist
+61.198,0,Artist
+61.200.1,0,Artist
+62.126,0,Artist
+62.16,0,Maker
+62.189,0,Artist
+62.256.3,0,Artist
+62.55,0,Artist
+62.79.1,0,Artist
+62.79.2,0,Artist
+62.95,0,Artist
+62.96,0,Artist
+63.1,0,Artist
+63.11.6,0,
+63.11.6,1,
+63.11.6,2,
+63.178.1,0,Maker
+63.201.1,0,Artist
+63.210.11,0,Author
+63.210.11,1,Artist
+63.350.246.206.378,0,Publisher
+63.4,0,Artist
+63.73,0,Artist
+64.148,0,Artist
+64.79,0,Maker
+64.79,1,Maker
+65.167.6,0,Maker
+65.167.6,1,Maker
+65.247,0,Artist
+65.47,0,Manufactory
+65.49,0,Artist
+66.113,0,Artist
+66.126,0,Artist
+66.143,0,Artist
+66.244.1-.25,0,Artist
+67.110.1,0,Artist
+67.110.1,1,Patron
+67.187.121,0,Artist
+67.187.123,0,Artist
+67.187.53a-c,0,Artist
+67.197,0,Artist
+67.232,0,Artist
+67.241,0,Artist
+67.25,0,Artist
+67.855,0,Printer
+67.855,1,Printer
+67.855,2,Artist
+67.855,3,Publisher
+68.1,0,Artist
+68.100.1,0,Maker
+68.141.81a–f,0,Maker
+68.185,0,Artist
+69.113,0,Artist
+"69.140a, b",0,Maker
+69.27,0,Poet
+69.27,1,Artist
+69.88,0,Artist
+7.122,0,Artist
+7.123,0,Artist
+7.16,0,Artist
+7.79,0,Artist
+72.3,0,Artist
+74.24,0,Artist
+75.7.2,0,Artist
+"77.9a, b",0,Designer
+"77.9a, b",1,Manufacturer
+"77.9a, b",2,Decorator
+"77.9a, b",3,Designer
+8.228,0,Artist
+80.1.2,0,Artist
+87.25,0,Artist
+87.8.8,0,Artist
+88.5a–d,0,Artist
+89.15.19,0,Artist
+89.15.21,0,Artist
+89.21.1,0,Artist
+89.4.1097,0,Maker
+89.4.1191,0,Maker
+89.4.1191,1,Maker
+89.4.1196,0,Maker
+89.4.1219,0,Maker
+89.4.1236,0,Maker
+89.4.2058,0,Maker
+89.4.2375,0,Maker
+"89.4.2631 a, b",0,Maker
+"89.4.28 a, b",0,Maker
+89.4.2883,0,Maker
+89.4.2929a–e,0,Designer
+89.4.2929a–e,1,Artist
+89.4.2929a–e,2,Artist
+89.4.909,0,Maker
+89.4.912,0,Maker
+89.4.924,0,Maker
+89.4.926,0,Culture
+9.95,0,Artist
+903.6 R541 F,0,Author
+903.6 R541 F,1,Author
+903.6 R541 F,2,Author
+91.1.535a–h,0,Maker
+911.1. M362,0,Author
+912.1 K63 Q,0,Author
+912.63 D23,0,Author
+916.3 An4 F,0,Author
+920.3 W52 F,0,Author
+920.84 M292,0,Author
+920.84 M292,1,Illustrator
+926.1 M642,0,Author
+94.14,0,Artist
+94.4.172,0,Factory
+94.9.3,0,Artist
+959.9 M292,0,Author
+96.17.10,0,Designer
+96.17.10,1,Maker
+96.29,0,Artist
+97.13.1,0,Artist
+97.19,0,Artist
+97.29.3,0,Artist
+97.33,0,Artist
+97.34,0,Artist
+99.2,0,Manufacturer
+99.2,1,Designer
+99.31,0,Artist
+AE25 .E53 1751 Q,0,Publisher
+AE25 .E53 1751 Q,1,Author
+AE25 .E53 1751 Q,2,Author
+AE25 .E531 1762 Q,0,Author
+AE25 .E531 1762 Q,1,Publisher
+AE25 .E531 1762 Q,2,Author
+AE25 .E531 1762 Q,3,Author
+AE25 .E532 1758 Q,0,Author
+AE25 .E532 1758 Q,1,Publisher
+AE25 .E532 1758 Q,2,Author
+AE25 .E532 1758 Q,3,Author
+AE25 .E533 1765 Q,0,Publisher
+AE25 .E533 1765 Q,1,Author
+AY831 .Z7 1783,0,Publisher
+AY831 .Z7 1784,0,Printer
+AY831 .Z7 1784,1,Author
+AY831 .Z7 1784a,0,Publisher
+AY831 .Z7 1788,0,Publisher
+AY831 .Z7 1792,0,Editor
+AY831 .Z7 1792,1,Publisher
+BF207 .L4 1972,0,Author
+BF207 .L4 1972,1,Author
+BF207 .L4 1972,2,Author
+BF209.M4 M5313 1963,0,Author
+BS75 1785b Q,0,Printer
+BS75 1785b Q,1,Author
+BV4823 .D48 1741,0,Designer
+BV4823 .D48 1741,1,Engraver
+BV4823 .D48 1741,2,Engraver
+BV4834 .A75 1696,0,Author
+BX2010 .A2 1794,0,Author
+BX2010 .A2 1794,1,Artist
+BX2010 .A2 1794,2,Author
+BX2010 .A2 1794,3,Artist
+BX2010 .A2 1794,4,Artist
+BX2010 .A2 1794,5,Publisher
+BX2016.A5 F7 1792,0,Author
+BX2016.A5 F7 1792,1,Publisher
+BX9454 .S25 1688,0,Printer
+BX9454 .S25 1688,1,Author
+C.I.42.33.3,0,Designer
+C.I.44.64.8a–c,0,Designer
+C.I.44.64.8a–c,1,Design House
+"C.I.45.27a, b",0,Designer
+"C.I.46.4.18a, b",0,Designer
+"C.I.46.4.18a, b",1,Design House
+C.I.46.4.20a–c,0,Design House
+"C.I.46.57a, b",0,Designer
+C.I.50.110a–j,0,Designer
+C.I.50.44,0,Designer
+C.I.50.44,1,Design House
+C.I.51.83,0,Designer
+C.I.52.18.4,0,Designer
+C.I.52.5.2,0,Design House
+C.I.53.40.7a–e,0,Designer
+C.I.53.40.7a–e,1,Design House
+C.I.53.73,0,Designer
+"C.I.54.16.1a, b",0,Designer
+"C.I.54.16.1a, b",1,Design House
+C.I.57.17.3,0,Designer
+"C.I.58.13.6a, b",0,Designer
+"C.I.58.13.6a, b",1,Design House
+C.I.58.25a–c,0,Designer
+C.I.58.34.30,0,Designer
+C.I.58.34.30,1,Design House
+"C.I.58.49.4a, b",0,Designer
+"C.I.58.49.4a, b",1,Manufacturer
+"C.I.60.21.1a, b",0,Designer
+"C.I.60.21.1a, b",1,Design House
+C.I.61.40.4,0,Designer
+C.I.66.14.2,0,Designer
+C.I.66.14.2,1,Manufacturer
+C.I.68.53.5a–h,0,Designer
+C.I.69.23,0,Designer
+C.I.69.23,1,Design House
+C.I.X.56.2.1,0,Design House
+C.I.X.56.2.1,1,Designer
+DA447.G7 H26 1876,0,Author
+DA447.G7 H26 1876,1,Illustrator
+DA447.G7 H26 1876,2,Printer
+DA447.G7 H26 1876,3,Binder
+DC122.8 .P413 1785,0,Translator
+DC122.8 .P413 1785,1,Author
+DC130.L14 L14 1749,0,Author
+DC611.N846 A5 1788,0,Publisher
+DH188.H67 W47 1568,0,Author
+F595 .R38 1895,0,Publisher
+F595 .R38 1895,1,Artist
+G150 .A45 1820,0,Publisher
+GB1321 .M68 1766,0,Author
+GT2050 .U813 1884,0,Illustrator
+GT2050 .U813 1884,1,Publisher
+GT2050 .U813 1884,2,Author
+GV1801 .L6 1889,0,Author
+GV1801 .L6 1889,1,Illustrator
+GV1801 .L6 1889,2,Publisher
+KKL273.1.Z94 C4 1815,0,Binder
+"L.2009.22.279a, b",0,Maker
+M2149.5 .C5 1768,0,Author
+M2149.5 .C5 1768,1,Calligrapher
+N6659.P32 A4 1976,0,Publisher
+N6659.P32 A4 1976,1,Author
+N6659.P32 A4 1976,2,Author
+N7433.4.B76 P43 1966,0,Artist
+N7433.4.C65 D43 2015,0,Printer
+N7433.4.C65 D43 2015,1,Publisher
+N7433.4.C65 D43 2015,2,Artist
+N7433.4.C65 D43 2015,3,Artist
+NC765 .A9 1683 Q,0,Printmaker
+ND3365.G7 B74 2009a Q,0,Editor
+ND3365.G7 B74 2009a Q,1,Editor
+ND3365.G7 B74 2009a Q,2,Author
+ND3365.G7 B74 2009a Q,3,Publisher
+ND616 .G35 1812,0,Editor
+ND616 .G35 1812,1,Printer
+ND616 .G35 1812,2,Binder
+NE2049.5.W38 W38 1710,0,Artist
+NE2049.5.W38 W38 1710,1,Engraver
+NE2049.5.W38 W38 1710,2,Engraver
+NE2049.5.W38 W38 1710,3,Engraver
+NE2049.5.W38 W38 1710,4,Binder
+NK1483 .J7 1867 Q,0,Publisher
+NK1483 .J7 1867 Q,1,Author
+NK1510 .J7 1868 Q,0,Author
+NK1510 .J7 1868 Q,1,Artist
+NK1510 .J7 1868 Q,2,Artist
+NK1510 .J7 1868 Q,3,Publisher
+NK1510 .J7 1868 Q,4,Artist
+NK1530 .A5 1930,0,Publisher
+NK1530 .A5 1930,1,Editor
+NK1530 .A5 1930,2,Editor
+NK1530 .A5 1930,3,Author
+NK1700 .I57 Q v.1 1900,0,Publisher
+NK1700 .I57 Q v.1 1900,1,Editor
+NK1700 .I57 Q v.2 1901,0,Publisher
+NK1700 .I57 Q v.2 1901,1,Editor
+NK2229 .S54 1793,0,Publisher
+NK2229 .S54 1793,1,Printer
+NK2229 .S54 1793,2,Author
+NK7983.A1 W36 1752,0,Author
+NX511.A88 A88 1971 Quarto,0,Editor
+NX511.A88 A88 1971 Quarto,1,Editor
+NX511.A88 A88 1971 Quarto,2,Author
+PA4375.M8 D3 1772,0,Author
+PA4375.M8 D3 1772,1,Publisher
+PA4375.M8 D3 1772,2,Artist
+PA6525.H4 N3 1762,0,Author
+PA6525.H4 N3 1762,1,Illustrator
+PA6525.H4 N3 1762,2,Publisher
+PA6525.H4 N3 1762,3,Author
+PA6525.H4 N3 1762,4,Translator
+PA6555 .A2 1585,0,Author
+PA6555 .A2 1585,1,Author
+PA6555 .A2 1585,2,Author
+PA6555 .A2 1585,3,Publisher
+PA6555 .A2 1585,4,Printer
+PA6555 .A2 1585,5,Author
+PA6558 .A5 1726,0,Author
+PA6558 .A5 1726,1,Author
+PL2693.H76 H74 1977 Quarto,0,Author
+PL2693.H76 H74 1977 Quarto,1,Artist
+PL2693.H76 H74 1977 Quarto,2,Author
+PN1489 .M37 1651,0,Author
+PN1489 .M37 1651,1,Author
+PN1489 .M37 1651,2,Binder
+PN1489 .M37 1651,3,Author
+PN1489 .M37 1651,4,Author
+PN6231.P6 B63 1669,0,Printer
+PN6231.P6 B63 1669,1,Author
+PN6231.P6 B63 1669,2,Binder
+PN6231.P6 B63 1669,3,Author
+PQ1189 .M66 1765,0,Publisher
+PQ1189 .M66 1765,1,Author
+PQ1189 .M66 1765,2,Author
+PQ1795 .T5 1790,0,Author
+PQ1795 .T5 1790,1,Engraver
+PQ1795 .T5 1790,2,Engraver
+PQ1795 .T5 1790,3,Binder
+PQ1809 .A1 1795,0,Author
+PQ1809 .A1 1795,1,Author
+PQ1809 .A1 1795,2,Draftsman
+PQ1809 .A1 1795,3,Printer
+PQ1821 1773,0,Author
+PQ1821 1773,1,Printer
+PQ1821 1773,2,Author
+PQ1821 1773,3,Author
+PQ1821 1773,4,Illustrator
+PQ1821 1773,5,Illustrator
+PQ1821 1773,6,Publisher
+PQ1954.A54 L4 1741,0,Author
+PQ1954.A54 L4 1741,1,Publisher
+PQ2067.T28 D4 1770,0,Author
+PQ2067.T28 D4 1770,1,Author
+PQ2067.T28 D4 1770,2,Publisher
+PQ4272.F5 A34 1697,0,Binder
+PQ4272.F5 A34 1697,1,Printer
+PQ4272.F5 A34 1697,2,Author
+PQ4272.F5 A34 1697,3,Printmaker
+PQ4567 .A2 1584,0,Author
+PQ4567 .A2 1584,1,Author
+PQ4567 .A2 1584,2,Author
+PQ4567 .A2 1584,3,Author
+PQ4567 .A2 1584,4,Author
+PQ4567 .A2 1584,5,Author
+PQ4567 .A2 1584,6,Author
+PQ4567 .A2 1584,7,Author
+PQ4567 .A2 1584,8,Author
+PQ4567 .A2 1584,9,Author
+PQ4567 .A2 1584,10,Publisher
+PQ4567 .A2 1584,11,Engraver
+PS2267 .A1 1891,0,Publisher
+PS2267 .A1 1891,1,Illustrator
+PS2267 .A1 1891,2,Author
+PS3519.O2625 G6 1927,0,Artist
+PS3519.O2625 G6 1927,1,Author
+PS3519.O2625 G6 1927,2,Publisher
+PS3519.O2625 G6 1927,3,Artist
+QB7 .C15 1772,0,Publisher
+SB472.32.E54 W48 1771,0,Translator
+SB472.32.E54 W48 1771,1,Author
+SB472.32.E54 W48 1771,2,Publisher
+TA71 .F73 1829,0,Author
+TA71 .F73 1829,1,Publisher
+TL620.A1 A6 1784,0,Publisher
+TL620.A1 A6 1784a,0,Publisher
+TS1484 .B56 1777,0,Author
+TS1484 .B56 1777,1,Publisher
+U101 .M7814 1760,0,Author
+U565 .S68 1740,0,Author
+U565 .S68 1740,1,Binder
+U820.A9 S34 1603 F,0,Author
+U820.A9 S34 1603 F,1,Translator
+U820.A9 S34 1603 F,2,Publisher
+U820.A9 S34 1603 F,3,Engraver
+U820.A9 S34 1603 F,4,Illustrator
+UD S83 1842 v.1,0,Author
+UD S83 1843 v.2,0,Author

--- a/scripts/output/met_artwork/met_attribution_unique.csv
+++ b/scripts/output/met_artwork/met_attribution_unique.csv
@@ -1,0 +1,129 @@
+attribution
+After
+After a design by
+Appresso
+Armor attributed to
+Attributed to
+Attributed to the
+Attributed to the pottery of
+Aux depens de
+Blade by
+Blade inscribed by
+Border probably designed by
+"Breastplate inscribed inside,"
+Calligraphy and paintings by
+Case after a design by
+Cast by
+Central plaque decorated by
+Chair rails and paneling carved by
+Chased by
+Chez
+Chimneypiece by
+Circle of
+"Circle of Rogier van der Weyden, possibly"
+Commissioned by
+Commissioned for
+Copy of work attributed to
+De
+De l'imprimerie de
+Decoration after designs by
+Decoration after drawings by
+Design attributed to
+Design of the decoration attributed to
+Designed and possibly engraved by
+Designed and steel chiseled by
+Designed by
+Designs for figural marquetry by
+Doors by
+Embroidered by
+Engraver:
+Engravings drawn by
+Erroneously attributed to
+Executed in the workshop of
+Executed under the supervision of
+Factory administrator:
+Follower of
+Foreword by
+Formerly attributed to
+Frieze mounts attributed to
+Furniture and curtain cornices made by
+Grate basket and fender by
+Grip attributed to
+Helmet bowl signed
+Helmet cheek pieces and metal plates on shoulder straps made by
+Helmet includes original paper label of
+Helmet signed by
+Hilt by
+Historical descriptions by
+Inscribed by
+Introduction by
+Introduction by:
+Issued by
+Lithographed by
+Long sword (katana) blade inscribed by
+Made at the
+Made under the direction of
+Manufactured by
+Marble chimneypiece supplied by
+Marble piers carved by
+Marquery commode made by
+Marquetry by
+Marquetry panel after a design by
+Medallions by
+Miniatures by
+Mounts and large central plaque by
+Organ mechanism made by
+Painted by
+Painting attributed to
+Painting by
+Par
+Part of the decoration design by
+Part of the decoration design possibly by
+Partly based on a woodcut by
+Pietre Dure top attributed to
+Plaster ceiling and cornice moldings by
+Plaster ceiling by
+Possibly
+Possibly assisted by
+Possibly by
+Possibly executed by
+Presso
+Printer:
+Probably
+Probably by
+Probably made at the
+Probably woven by
+Published by
+Restored by
+Roman copy of Greek original by
+Room after a design by
+Sculptor close to
+Set of sword mountings by
+Short sword (wakizashi) blade attributed to
+Signature probably refers to
+Signed by
+Silver mounts by
+"Stamped with the armorer's name,"
+Stencil drawings and stamp-cutting of marquetry
+Stuccowork probably by
+Tapestries and furniture covers manufactured by
+Tapestry and seat furniture designs possibly by
+Tapestry borders and seat covers designed by
+Tapestry medallions after designs by
+Textile by
+Woodwork by
+Woodwork carved by
+Workshop of
+Woven by
+Written by
+after
+and
+attributed to
+commissioned by
+for the firm
+labeled
+possibly
+possibly embroidered by
+various
+with frieze carved by
+workshop of

--- a/scripts/output/met_artwork/met_roles_unique.csv
+++ b/scripts/output/met_artwork/met_roles_unique.csv
@@ -1,0 +1,48 @@
+role
+""
+Armorer
+Artist
+Author
+Barrelsmith
+Binder
+Bladesmith
+Calligrapher
+Culture
+Decorator
+Dedicatee
+Department Store
+Design House
+Designer
+Draftsman
+Editor
+Engraver
+Etcher
+Factory
+Factory director
+Fittings maker
+Former Attribution
+Founder
+Goldsmith
+Gunsmith
+Illuminator
+Illustrator
+Maker
+Manufactory
+Manufacturer
+Modeler
+Patron
+Person in Photograph
+Photographer
+Photography Studio
+Poet
+Printer
+Printmaker
+Publisher
+Retailer
+Silversmith
+Sitter
+Subject of book
+Sword cutler
+Sword maker
+Swordsmith
+Translator


### PR DESCRIPTION
This PR adds the following:

* Pandas script: adds routines that "explode" comma-delimited string values into row values 
* SQL script: Adds `artist`, `artwork_artist` (M2M), `artist_role`, and `artwork_attribution` tables and data